### PR TITLE
docs: replace python -m web.server with harness-pr-review web

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pip install -e .       # refresh entry points if pyproject.toml changed
 - The auto-review poller (launchd/cron) picks up the new code on its next
   pass — no restart needed.
 - A running web dashboard keeps the old code until restarted: stop the
-  process, then start it again (`python -m web.server`).
+  process, then start it again (`harness-pr-review web`).
 - Your existing `sessions/` data and `autoreview.yml` are preserved — updates
   never touch them.
 
@@ -154,8 +154,8 @@ per repo). Reads `sessions/` directly — no database.
 
 ```bash
 pip install -e '.[web]'
-DSH_SESSION_ROOT=sessions python -m web.server
-# open http://127.0.0.1:6789
+DSH_SESSION_ROOT=sessions harness-pr-review web
+harness-pr-review web   # open http://127.0.0.1:6789
 ```
 
 Pages: repo list → repo detail (KPIs + verdict donut + PR table) → PR detail

--- a/docs/guide/how-to-automate-pr-review-with-deepseek.html
+++ b/docs/guide/how-to-automate-pr-review-with-deepseek.html
@@ -79,7 +79,7 @@ autoreview --daemon</code></pre>
 <h2>Step 4 — See the results</h2>
 <p>The web dashboard shows per-repo KPIs: PRs reviewed, bugs found,
 doc errors, verdict distribution, and review rounds:</p>
-<pre><code>python -m web.server   # open http://127.0.0.1:6789</code></pre>
+<pre><code>harness-pr-review web   # open http://127.0.0.1:6789</code></pre>
 
 <h2>What happens when the agent is uncertain</h2>
 <p>The agent never guesses. Anything it cannot verify is marked

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,7 +87,7 @@ harness-pr-review doctor                                  # check readiness
 harness-pr-review https://github.com/owner/repo/pull/123  # review one PR
 harness-pr-review owner/repo 123                          # or owner/repo + number
 autoreview --daemon                                       # auto review every 2 min
-python -m web.server                                      # dashboard at :6789</code></pre>
+harness-pr-review web                                   # dashboard at :6789</code></pre>
 
 <hr>
 


### PR DESCRIPTION
## Summary
- README: web dashboard section uses `harness-pr-review web`
- Landing page + guide: quickstart uses `harness-pr-review web`
- Docs-only PR — no code changes (v1.0.4 already on main)

## Test Plan
- [ ] Grep verified: no `python -m web.server` remains in README/docs