### PR TITLE
chore: bump to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepseek-harness-pr-review"
-version = "1.1.0"
+version = "1.2.0"
 description = "Headless PR review automation on top of DeepSeek Harness"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,13 @@
-__version__ = "1.0.6"
+"""Headless PR review automation built on the DeepSeek Harness SDK."""
+import importlib.metadata
+
+DIST_NAME = "deepseek-harness-pr-review"
+
+try:
+    # Single source of truth is pyproject.toml, read through the installed
+    # distribution. A hand-written literal here drifted to 1.0.6 while
+    # pyproject said 1.1.0, and `--version` (which already read the metadata)
+    # disagreed with `src.__version__` for several releases.
+    __version__ = importlib.metadata.version(DIST_NAME)
+except importlib.metadata.PackageNotFoundError:  # running from a plain checkout
+    __version__ = "0+unknown"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,3 +2,19 @@ def test_package_imports():
     import src  # noqa: F401
 
     assert src.__version__
+
+
+def test_version_matches_pyproject():
+    """One version, one source. These drifted (1.0.6 vs 1.1.0) once already."""
+    import re
+    import tomllib
+    from pathlib import Path
+
+    import src
+
+    root = Path(__file__).resolve().parent.parent
+    declared = tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"]
+    assert src.__version__ == declared, (
+        f"src.__version__ ({src.__version__}) != pyproject ({declared}) — "
+        f"reinstall the package (pip install -e .) or fix the declaration")
+    assert re.fullmatch(r"\d+\.\d+\.\d+", declared)


### PR DESCRIPTION
Version bump for the work merged in #12.

`1.1.0` → `1.2.0` — new features (undescribed-PR review path, verify fan-out with a global agent cap, ranked doc targets), no removals.

**Note for anyone parsing verdicts:** `MISLEADING` is now `CONTRADICTED`, and every verdict label carries its proportion (`1 of 23 claims contradicted`). Verdicts are recomputed from `findings.json` on read, so stored sessions need no migration — but tooling matching the old string will stop matching. If you consider the verdict vocabulary a public contract, this is arguably a major bump; treated as minor here since it is an app, not a library, and nothing outside the repo consumes those strings.

## Two things the bump uncovered

**The version was two different numbers.** `pyproject.toml` said `1.1.0`, `src/__init__.py` said `1.0.6`. `--version` reads the installed metadata, so it had been disagreeing with `src.__version__` for several releases. `__init__` now derives from the distribution, and `test_version_matches_pyproject` asserts the two agree so this cannot drift again.

**That test failed at `0.1.0`.** A stale `src/deepseek_harness_pr_review.egg-info` from an older packaging layout was shadowing the real metadata — `src/` is on `sys.path` under pytest, so the lookup found the stale copy first. Removed; it was untracked build output that `.gitignore` already covered.

238 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)