### PR TITLE
feat: verify a repo exists before adding it, and surface ones that vanished

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ and live demo data are included — see [Web dashboard](#web-dashboard).
 | ✅ **Human-in-the-loop** | ≤20-word confirmation questions only when uncertain — no guessing |
 | ✅ **Parallel agents** | One agent per review axis (claims / docs / impact), claims sharded past 15 — so a 40-claim PR cannot starve the docs check. Concurrency is capped globally across every review process |
 | ✅ **Ranked doc targets** | Docs are scored against the diff (path proximity, changed symbols, file mentions) before any agent runs — the agent verifies a bounded, reproducible list instead of grepping the repo |
+| ✅ **Repo config that stays true** | Adding a repo verifies it exists and is visible to your token first, so a typo cannot become a permanent config entry. `autoreview --check-repos` (and the /config page) flags entries GitHub can no longer reach and removes them in one click |
 | ✅ **Auto review poller** | Reviews new PRs automatically, re-reviews when the head commit changes |
 | ✅ **Web dashboard** | Repo config management, review triggers (Review now), live review logs, metrics: risks found, doc errors, verdicts, review rounds per repo |
 | ✅ **Idempotent PR comments** | One English comment per PR, updated in place — never duplicated |

--- a/autoreview.yml.example
+++ b/autoreview.yml.example
@@ -19,6 +19,8 @@ max_agents: 4                # concurrent model agents across the WHOLE system, 
                              # so in-flight calls = max_parallel x agents per review.
                              # Enforced by lock files, so every review process and
                              # every manual CLI run shares the one budget. Max 16.
-repos:
+repos:                       # adding a repo checks it exists and is visible
   your-repo: auto            # auto-review this repo's PRs
   another-repo: manual       # skip in poller; review via CLI/UI
+                             # `autoreview --check-repos` reports unreachable
+                             # entries; the /config page flags and removes them

--- a/src/autoreview.py
+++ b/src/autoreview.py
@@ -269,6 +269,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--add-repo", metavar="REPO",
                         help="add repo (name or owner/name) and set its mode")
     parser.add_argument("--rm-repo", metavar="REPO", help="remove a repo")
+    parser.add_argument("--force-add", action="store_true",
+                        help="add the repo even if GitHub cannot see it")
+    parser.add_argument("--check-repos", action="store_true",
+                        help="report which configured repos GitHub cannot reach")
     parser.add_argument("--mode", choices=["auto", "manual"], default="auto",
                         help="mode for --add-repo (default: auto)")
     parser.add_argument("--repos", action="store_true",
@@ -287,6 +291,28 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"error: cannot parse repo from: {raw!r}", file=sys.stderr)
                 return 2
             repo_ref_key = raw  # tên trần → org từ config
+
+        # Kiểm tra trước khi ghi: một cái tên gõ sai từng thành entry vĩnh viễn
+        # trong autoreview.yml mà poller retry mỗi pass.
+        from src.repo_check import ACTIONABLE, UNKNOWN, check_repo
+
+        if "/" in repo_ref_key:
+            owner, name = repo_ref_key.split("/", 1)
+        else:
+            try:
+                owner, name = load_config(args.config).get("org", ""), repo_ref_key
+            except (ValueError, OSError):
+                owner, name = "", repo_ref_key
+        if owner and name:
+            check = check_repo(owner, name)
+            if check["status"] in ACTIONABLE and not args.force_add:
+                print(f"error: {owner}/{name}: {check['detail']}\n"
+                      f"       use --force-add to add it anyway", file=sys.stderr)
+                return 2
+            if check["status"] == UNKNOWN:
+                print(f"warning: could not verify {owner}/{name}: "
+                      f"{check['detail']}", file=sys.stderr)
+
         set_repo_mode(args.config, repo_ref_key, args.mode)
         print(f"{repo_ref_key} -> {args.mode}")
         return 0
@@ -294,6 +320,32 @@ def main(argv: list[str] | None = None) -> int:
         remove_repo(args.config, args.rm_repo)
         print(f"removed {args.rm_repo}")
         return 0
+    if args.check_repos:
+        from src.autoreview_config import list_repos as _list_repos
+        from src.repo_check import ACTIONABLE, check_repos
+
+        cfg = load_config(args.config)
+        org = cfg.get("org") or ""
+        names = [r["name"] for r in _list_repos(args.config)
+                 if r["mode"] != "unlisted"]
+        pairs = [tuple(n.split("/", 1)) if "/" in n else (org, n) for n in names]
+        results = check_repos([(o, r) for o, r in pairs if o and r])
+        bad = 0
+        for name, (owner, repo_name) in zip(names, pairs):
+            result = results.get(f"{owner}/{repo_name}",
+                                 {"status": "unknown", "detail": "no org configured"})
+            mark = "ok " if result["status"] == "ok" else result["status"]
+            if result["status"] in ACTIONABLE:
+                bad += 1
+            print(f"{mark:<10} {name}"
+                  + (f"  — {result['detail']}" if result["status"] != "ok" else ""))
+        # Report on stdout so it stays interleaved with the list; the exit
+        # code is the part a script reads.
+        if bad:
+            print(f"\n{bad} unreachable — remove with: "
+                  f"autoreview --rm-repo <name>")
+        return 1 if bad else 0
+
     if args.repos:
         for r in list_repos(args.config):
             print(f"{r['name']:<40} {r['mode']}")

--- a/src/repo_check.py
+++ b/src/repo_check.py
@@ -1,0 +1,64 @@
+"""Does this repo exist, and can we see it?
+
+A repo name is added to autoreview.yml by hand or by one click, and nothing ever
+checked it. A typo — or a bare name resolved against the wrong `org` — became a
+permanent config entry that the poller retried every pass and that showed up on
+the dashboard as a real repo with "No reviews yet", indistinguishable from one
+that simply has no open PRs.
+
+GitHub answers 404 both for a repo that does not exist and for a private repo
+the token cannot see; it does not tell the two apart, so neither do we.
+"""
+import re
+from concurrent.futures import ThreadPoolExecutor
+
+OK = "ok"
+MISSING = "missing"          # 404: gone, renamed, or private to this token
+FORBIDDEN = "forbidden"      # 403/401: seen but refused (SAML, rate limit, scope)
+UNKNOWN = "unknown"          # the check itself could not run
+
+# Statuses that justify refusing an add or offering a removal. UNKNOWN never
+# does: a network blip must not delete a repo or block a legitimate one.
+ACTIONABLE = (MISSING, FORBIDDEN)
+
+MAX_PARALLEL_CHECKS = 8
+
+_HTTP_CODE = re.compile(r"HTTP (\d{3})")
+
+
+def check_repo(owner: str, repo: str, gh=None) -> dict:
+    """{"status", "detail"} for one repo. Never raises.
+
+    gh is resolved at call time, not import time, so patching src.gh.run_gh
+    reaches this the same way it reaches autoreview_config.list_repos.
+    """
+    if gh is None:
+        from src.gh import run_gh as gh
+    try:
+        data = gh(["api", f"repos/{owner}/{repo}", "--jq", ".full_name"])
+    except (RuntimeError, OSError) as e:
+        message = str(e)
+        code = _HTTP_CODE.search(message)
+        code = code.group(1) if code else ""
+        if code == "404":
+            return {"status": MISSING,
+                    "detail": "not found — deleted, renamed, or not visible "
+                              "to this GitHub token"}
+        if code in ("401", "403"):
+            return {"status": FORBIDDEN,
+                    "detail": f"access refused (HTTP {code}) — check token "
+                              f"scopes or SAML authorisation"}
+        return {"status": UNKNOWN, "detail": message[:200]}
+    if not data:
+        return {"status": UNKNOWN, "detail": "empty response from gh"}
+    return {"status": OK, "detail": str(data)}
+
+
+def check_repos(pairs: list[tuple[str, str]], gh=None) -> dict:
+    """Check many repos at once. Keyed by "owner/repo"; never raises."""
+    if not pairs:
+        return {}
+    workers = min(MAX_PARALLEL_CHECKS, len(pairs))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        results = list(pool.map(lambda p: check_repo(p[0], p[1], gh), pairs))
+    return {f"{o}/{r}": result for (o, r), result in zip(pairs, results)}

--- a/tests/test_autoreview.py
+++ b/tests/test_autoreview.py
@@ -111,6 +111,7 @@ def test_main_add_repo_writes_config(tmp_path, monkeypatch):
     cfg_path = tmp_path / "autoreview.yml"
     cfg_path.write_text("org: sample-org\nrepos:\n  sample-app: manual\n")
     monkeypatch.setattr("src.autoreview.CONFIG_PATH", cfg_path)
+    monkeypatch.setattr("src.gh.run_gh", lambda args, **kw: "ok/repo")
     code = main(["--add-repo", "admin-web", "--mode", "auto"])
     assert code == 0
     cfg = load_config(cfg_path)
@@ -279,6 +280,7 @@ def test_main_add_repo_url(tmp_path, monkeypatch):
     cfg_path = tmp_path / "autoreview.yml"
     cfg_path.write_text("org: sample-org\nrepos:\n  sample-app: manual\n")
     monkeypatch.setattr("src.autoreview.CONFIG_PATH", cfg_path)
+    monkeypatch.setattr("src.gh.run_gh", lambda args, **kw: "ok/repo")
     code = main(["--add-repo", "https://github.com/sample-org/sample-api",
                  "--mode", "auto"])
     assert code == 0
@@ -290,6 +292,7 @@ def test_main_add_repo_bare_name_uses_org(tmp_path, monkeypatch):
     cfg_path = tmp_path / "autoreview.yml"
     cfg_path.write_text("org: sample-org\nrepos:\n  sample-app: manual\n")
     monkeypatch.setattr("src.autoreview.CONFIG_PATH", cfg_path)
+    monkeypatch.setattr("src.gh.run_gh", lambda args, **kw: "ok/repo")
     code = main(["--add-repo", "sample-app2", "--mode", "auto"])
     assert code == 0
     assert load_config(cfg_path)["repos"]["sample-app2"] == "auto"
@@ -448,3 +451,65 @@ def test_run_pass_skips_corrupt_review_lock_as_stale(tmp_path, monkeypatch):
                     gh=lambda args, **kw: [{"number": 1, "head": {"sha": "a"},
                                             "draft": False}]) == 1
     assert dispatched == [1]
+
+
+def test_add_repo_refuses_one_github_cannot_see(tmp_path, capsys, monkeypatch):
+    from src.autoreview import main
+
+    cfg = tmp_path / "autoreview.yml"
+    cfg.write_text("org: acme\nrepos: {}\n")
+
+    def gh(args, **kw):
+        raise RuntimeError("gh api failed: gh: Not Found (HTTP 404)")
+
+    monkeypatch.setattr("src.gh.run_gh", gh)
+    code = main(["--add-repo", "typoed", "--config", str(cfg)])
+    assert code == 2
+    assert "not found" in capsys.readouterr().err
+    assert "typoed" not in cfg.read_text()
+
+
+def test_add_repo_can_be_forced(tmp_path, monkeypatch):
+    from src.autoreview import main
+    from src.autoreview_config import load_config
+
+    cfg = tmp_path / "autoreview.yml"
+    cfg.write_text("org: acme\nrepos: {}\n")
+    monkeypatch.setattr(
+        "src.gh.run_gh",
+        lambda args, **kw: (_ for _ in ()).throw(RuntimeError("gh: Not Found (HTTP 404)")))
+
+    assert main(["--add-repo", "later", "--config", str(cfg), "--force-add"]) == 0
+    assert load_config(cfg)["repos"]["later"] == "auto"
+
+
+def test_check_repos_reports_and_exits_nonzero(tmp_path, capsys, monkeypatch):
+    from src.autoreview import main
+
+    cfg = tmp_path / "autoreview.yml"
+    cfg.write_text("org: acme\nrepos:\n  good: auto\n  ghost: auto\n")
+
+    def gh(args, **kw):
+        if args[1].startswith("orgs/"):
+            return []
+        if args[1].endswith("ghost"):
+            raise RuntimeError("gh: Not Found (HTTP 404)")
+        return args[1].removeprefix("repos/")
+
+    monkeypatch.setattr("src.gh.run_gh", gh)
+    code = main(["--check-repos", "--config", str(cfg)])
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "missing" in out and "ghost" in out
+    assert "1 unreachable" in out
+
+
+def test_check_repos_exits_zero_when_all_reachable(tmp_path, monkeypatch):
+    from src.autoreview import main
+
+    cfg = tmp_path / "autoreview.yml"
+    cfg.write_text("org: acme\nrepos:\n  good: auto\n")
+    monkeypatch.setattr(
+        "src.gh.run_gh",
+        lambda args, **kw: [] if args[1].startswith("orgs/") else "acme/good")
+    assert main(["--check-repos", "--config", str(cfg)]) == 0

--- a/tests/test_repo_check.py
+++ b/tests/test_repo_check.py
@@ -1,0 +1,63 @@
+import pytest
+
+from src.repo_check import (FORBIDDEN, MISSING, OK, UNKNOWN, check_repo,
+                            check_repos)
+
+
+def _gh_raising(message):
+    def gh(args, **kw):
+        raise RuntimeError(message)
+    return gh
+
+
+def test_existing_repo_is_ok():
+    result = check_repo("demo", "app", gh=lambda args, **kw: "demo/app")
+    assert result["status"] == OK
+
+
+def test_404_reads_as_missing():
+    result = check_repo("demo", "gone",
+                        gh=_gh_raising("gh api failed: gh: Not Found (HTTP 404)"))
+    assert result["status"] == MISSING
+    # 404 covers both "deleted" and "private to this token" — say so, don't guess.
+    assert "not visible" in result["detail"]
+
+
+@pytest.mark.parametrize("code", ["401", "403"])
+def test_auth_failures_read_as_forbidden(code):
+    result = check_repo("demo", "app",
+                        gh=_gh_raising(f"gh api failed: gh: Forbidden (HTTP {code})"))
+    assert result["status"] == FORBIDDEN
+    assert code in result["detail"]
+
+
+def test_network_failure_is_unknown_not_missing():
+    """A blip must never be mistaken for a repo that does not exist."""
+    result = check_repo("demo", "app",
+                        gh=_gh_raising("dial tcp: connection refused"))
+    assert result["status"] == UNKNOWN
+
+
+def test_gh_binary_absent_is_unknown():
+    def gh(args, **kw):
+        raise OSError("No such file or directory: 'gh'")
+    assert check_repo("demo", "app", gh=gh)["status"] == UNKNOWN
+
+
+def test_empty_response_is_unknown():
+    assert check_repo("demo", "app", gh=lambda args, **kw: "")["status"] == UNKNOWN
+
+
+def test_check_repos_keys_by_full_name():
+    def gh(args, **kw):
+        if "gone" in args[1]:
+            raise RuntimeError("gh: Not Found (HTTP 404)")
+        return args[1].removeprefix("repos/")
+
+    results = check_repos([("demo", "app"), ("demo", "gone")], gh=gh)
+    assert results["demo/app"]["status"] == OK
+    assert results["demo/gone"]["status"] == MISSING
+
+
+def test_check_repos_empty_input():
+    assert check_repos([]) == {}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -550,19 +550,108 @@ def test_pr_page_never_reviewed_still_says_not_reviewed(tmp_path, monkeypatch):
     assert "Failed · interrupted" not in resp.text
 
 
-def _config_client(tmp_path, monkeypatch, body):
+def _cfg_client(tmp_path, monkeypatch, gh,
+                body="org: sample-org\nrepos:\n  sample-app: auto\n"):
     cfg_path = tmp_path / "autoreview.yml"
     cfg_path.write_text(body)
     monkeypatch.setenv("AUTOREVIEW_CONFIG", str(cfg_path))
     monkeypatch.setenv("DSH_SESSION_ROOT", str(tmp_path / "sessions"))
-    monkeypatch.setattr("src.gh.run_gh", lambda args, **kw: [])
+    monkeypatch.setattr("src.gh.run_gh", gh)
+    # The reachability cache is process-global; tests must not inherit each other.
+    import web.server
+    web.server._check_cache.clear()
     return TestClient(app), cfg_path
+
+def _gh_with_missing(missing):
+    """Org listing works; repos/<x> 404s for names in `missing`."""
+    def gh(args, **kw):
+        target = args[1]
+        if target.startswith("orgs/"):
+            return [{"name": "sample-app"}]
+        if any(target.endswith(m) for m in missing):
+            raise RuntimeError("gh api failed: gh: Not Found (HTTP 404)")
+        return target.removeprefix("repos/")
+    return gh
+
+
+def test_add_repo_refuses_one_github_cannot_see(tmp_path, monkeypatch):
+    client, cfg_path = _cfg_client(tmp_path, monkeypatch,
+                                   _gh_with_missing(["typoed-repo"]))
+    r = client.post("/api/config/repos", json={"repo": "typoed-repo"})
+    assert r.status_code == 400
+    assert "not found" in r.json()["detail"]
+    # The whole point: it must not reach the config file.
+    assert "typoed-repo" not in load_config(cfg_path)["repos"]
+
+
+def test_add_repo_accepts_a_reachable_one(tmp_path, monkeypatch):
+    client, cfg_path = _cfg_client(tmp_path, monkeypatch, _gh_with_missing([]))
+    r = client.post("/api/config/repos", json={"repo": "nexpeakcore/erp"})
+    assert r.status_code == 200
+    assert r.json()["warning"] is None
+    assert load_config(cfg_path)["repos"]["nexpeakcore/erp"] == "auto"
+
+
+def test_add_repo_survives_an_unverifiable_check(tmp_path, monkeypatch):
+    """A network blip must not block a legitimate repo — but must be said out loud."""
+    def gh(args, **kw):
+        if args[1].startswith("orgs/"):
+            return []
+        raise RuntimeError("dial tcp: connection refused")
+
+    client, cfg_path = _cfg_client(tmp_path, monkeypatch, gh)
+    r = client.post("/api/config/repos", json={"repo": "acme/thing"})
+    assert r.status_code == 200
+    assert "could not verify" in r.json()["warning"]
+    assert load_config(cfg_path)["repos"]["acme/thing"] == "auto"
+
+
+def test_check_endpoint_lists_unreachable_repos(tmp_path, monkeypatch):
+    client, _ = _cfg_client(
+        tmp_path, monkeypatch, _gh_with_missing(["ghost", "sample-org/gone"]),
+        body="org: sample-org\nrepos:\n  sample-app: auto\n  ghost: auto\n"
+             "  sample-org/gone: manual\n")
+    data = client.get("/api/config/repos/check").json()
+    assert data["unreachable"] == ["ghost", "sample-org/gone"]
+    assert data["repos"]["sample-app"]["status"] == "ok"
+    assert data["repos"]["ghost"]["status"] == "missing"
+
+
+def test_config_page_flags_and_can_remove_unreachable(tmp_path, monkeypatch):
+    client, cfg_path = _cfg_client(
+        tmp_path, monkeypatch, _gh_with_missing(["ghost"]),
+        body="org: sample-org\nrepos:\n  sample-app: auto\n  ghost: auto\n")
+    html = client.get("/config").text
+    assert "1 repo cannot be reached" in html
+    assert "ghost" in html
+
+    assert client.delete("/api/config/repos/ghost").status_code == 200
+    assert "ghost" not in load_config(cfg_path)["repos"]
+
+
+def test_repo_check_results_are_cached_until_rechecked(tmp_path, monkeypatch):
+    calls = []
+
+    def gh(args, **kw):
+        if args[1].startswith("orgs/"):
+            return []
+        calls.append(args[1])
+        return args[1].removeprefix("repos/")
+
+    client, _ = _cfg_client(tmp_path, monkeypatch, gh,
+                            body="repos:\n  acme/thing: auto\n")
+    client.get("/config")
+    assert len(calls) == 1
+    client.get("/config")            # cached — the page reloads after every edit
+    assert len(calls) == 1
+    client.get("/config?recheck=1")  # explicit re-check busts it
+    assert len(calls) == 2
 
 
 def test_repo_page_does_not_claim_auto_from_another_owners_bare_key(tmp_path, monkeypatch):
     """/repos/nexpeakcore/erp must not read `erp: auto`, which means sample-org/erp."""
-    client, _ = _config_client(
-        tmp_path, monkeypatch,
+    client, _ = _cfg_client(
+        tmp_path, monkeypatch, lambda args, **kw: [],
         "org: sample-org\ndefault_mode: manual\nrepos:\n  erp: auto\n")
 
     html = client.get("/repos/nexpeakcore/erp").text
@@ -574,8 +663,8 @@ def test_repo_page_does_not_claim_auto_from_another_owners_bare_key(tmp_path, mo
 def test_toggling_mode_from_a_repo_page_targets_that_owner(tmp_path, monkeypatch):
     from src.autoreview_config import load_config as load_acfg
 
-    client, cfg_path = _config_client(
-        tmp_path, monkeypatch, "org: sample-org\nrepos:\n  erp: auto\n")
+    client, cfg_path = _cfg_client(
+        tmp_path, monkeypatch, lambda args, **kw: [], "org: sample-org\nrepos:\n  erp: auto\n")
 
     r = client.post("/api/config/repos/nexpeakcore%2Ferp/mode", json={"mode": "auto"})
     assert r.status_code == 200
@@ -588,8 +677,8 @@ def test_config_routes_accept_owner_slash_repo_keys(tmp_path, monkeypatch):
     """Config keys contain slashes; a single-segment route 404'd on all of them."""
     from src.autoreview_config import load_config as load_acfg
 
-    client, cfg_path = _config_client(
-        tmp_path, monkeypatch,
+    client, cfg_path = _cfg_client(
+        tmp_path, monkeypatch, lambda args, **kw: [],
         "org: sample-org\nrepos:\n  nexpeakcore/erp-desktop: auto\n  erp: auto\n")
 
     r = client.post("/api/config/repos/nexpeakcore%2Ferp-desktop/mode",

--- a/web/server.py
+++ b/web/server.py
@@ -12,6 +12,7 @@ from src.autoreview_config import load_config as load_autoreview_config
 from src.autoreview_config import auto_repos, list_repos, remove_repo, set_repo_mode
 from src.autoreview_config import repo_mode as config_repo_mode
 from src.config import load_config
+from src.repo_check import ACTIONABLE, OK, UNKNOWN, check_repo, check_repos
 from src.review_proc import EXIT_TIMEOUT, run_review
 from web import metrics
 
@@ -28,6 +29,49 @@ def _session_root() -> Path:
 
 def _config_path() -> Path:
     return Path(os.environ.get("AUTOREVIEW_CONFIG", "autoreview.yml"))
+
+
+def _split(name: str, org: str | None) -> tuple[str, str]:
+    """"owner/repo" as-is; a bare name against the configured org."""
+    if "/" in name:
+        owner, _, repo = name.partition("/")
+        return owner, repo
+    return (org or ""), name
+
+
+# Reachability is checked on every /config load, so it is cached: the page is
+# refreshed after each edit and 13 repos would otherwise be 13 API calls a time.
+_CHECK_TTL_SECONDS = 300
+_check_cache: dict[str, tuple[float, dict]] = {}
+
+
+def _repo_status(names: list[str], org: str | None, *, refresh: bool = False) -> dict:
+    """{name: {status, detail}} for configured repos, cached for _CHECK_TTL_SECONDS."""
+    import time
+
+    now = time.monotonic()
+    if refresh:
+        _check_cache.clear()
+    fresh, stale = {}, []
+    for name in names:
+        hit = _check_cache.get(name)
+        if hit and now - hit[0] < _CHECK_TTL_SECONDS:
+            fresh[name] = hit[1]
+        else:
+            stale.append(name)
+
+    pairs = [(name, _split(name, org)) for name in stale]
+    pairs = [(name, owner, repo) for name, (owner, repo) in pairs if owner and repo]
+    results = check_repos([(o, r) for _, o, r in pairs])
+    for name, owner, repo in pairs:
+        result = results.get(f"{owner}/{repo}", {"status": UNKNOWN, "detail": ""})
+        _check_cache[name] = (now, result)
+        fresh[name] = result
+    # A bare name with no org configured cannot be resolved into a repo at all.
+    for name in stale:
+        fresh.setdefault(name, {"status": UNKNOWN,
+                                "detail": "no org configured; use owner/repo"})
+    return fresh
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -63,18 +107,28 @@ def repo_list(request: Request):
 
 
 @app.get("/config", response_class=HTMLResponse)
-def config_page(request: Request):
+def config_page(request: Request, recheck: int = 0):
     cfg_state = None
     path = _config_path()
     if path.exists():
         try:
             cfg = load_autoreview_config(path)
+            repos = list_repos(path)
+            # Only configured repos are checked. "unlisted" rows come from the
+            # org listing, so they exist by construction.
+            listed = [r["name"] for r in repos if r["mode"] != "unlisted"]
+            status = _repo_status(listed, cfg.get("org"), refresh=bool(recheck))
+            for r in repos:
+                r["check"] = status.get(r["name"], {"status": OK, "detail": ""})
             cfg_state = {
                 "org": cfg.get("org"),
                 "interval": cfg.get("interval_minutes"),
                 "drafts": cfg.get("drafts"),
                 "post_comment": cfg.get("post_comment"),
-                "repos": list_repos(path),
+                "repos": repos,
+                "unreachable": sorted(
+                    name for name, c in status.items()
+                    if c["status"] in ACTIONABLE),
                 "config_path": str(path),
             }
         except (ValueError, OSError) as e:
@@ -233,12 +287,26 @@ def api_add_repo(payload: dict):
             raise HTTPException(
                 status_code=400,
                 detail="org not set in config; use owner/repo format")
+        owner, name = _split(repo, cfg.get("org"))
+        # Check before writing. An unreachable name used to become a permanent
+        # config entry that the poller retried every pass and that the dashboard
+        # rendered as a real repo.
+        check = check_repo(owner, name)
+        if check["status"] in ACTIONABLE:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{owner}/{name}: {check['detail']}")
         set_repo_mode(path, repo, payload.get("mode", "auto"))
+        _check_cache.pop(repo, None)
     except HTTPException:
         raise
     except (ValueError, OSError) as e:
         raise HTTPException(status_code=400, detail=str(e))
-    return {"ok": True, "repo": repo}
+    # An unverifiable repo is still added — a network blip must not block work —
+    # but the caller is told the check did not actually pass.
+    warning = (f"could not verify {owner}/{name}: {check['detail']}"
+               if check["status"] == UNKNOWN else None)
+    return {"ok": True, "repo": repo, "warning": warning}
 
 
 @app.delete("/api/config/repos/{repo:path}")
@@ -250,7 +318,27 @@ def api_remove_repo(repo: str):
         remove_repo(path, repo)
     except (ValueError, OSError) as e:
         raise HTTPException(status_code=400, detail=str(e))
+    _check_cache.pop(repo, None)
     return {"ok": True, "repo": repo}
+
+
+@app.get("/api/config/repos/check")
+def api_check_repos(refresh: int = 0):
+    """Reachability of every configured repo."""
+    path = _config_path()
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="autoreview.yml not found")
+    try:
+        cfg = load_autoreview_config(path)
+        listed = [r["name"] for r in list_repos(path) if r["mode"] != "unlisted"]
+    except (ValueError, OSError) as e:
+        raise HTTPException(status_code=400, detail=f"invalid config: {e}")
+    status = _repo_status(listed, cfg.get("org"), refresh=bool(refresh))
+    return {
+        "repos": status,
+        "unreachable": sorted(n for n, c in status.items()
+                              if c["status"] in ACTIONABLE),
+    }
 
 
 def _review_lock_path(session_root: Path, owner: str, repo: str, n: int) -> Path:

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -94,7 +94,7 @@ tr.failed td { background: #fdecea; }
 .tag.auto, .v-auto, .v-accurate, .v-pass, .v-match, .v-resolved, .v-fixed {
   background: #eaf7ee; color: var(--green);
 }
-.tag.manual, .v-manual, .v-no_claims, .v-unverified, .v-outdated, .v-unaffected {
+.tag.manual, .v-manual, .v-no_claims, .v-unverified, .v-unknown, .v-outdated, .v-unaffected {
   background: #eef1f4; color: var(--gray);
 }
 .tag.unlisted, .v-unlisted { background: #f4f6f8; color: #a0a6ad; }
@@ -104,6 +104,9 @@ tr.failed td { background: #fdecea; }
 }
 .tag.fail, .v-contradicted, .v-fail, .v-fabricated, .v-broken, .v-inconsistent { background: #fdecea; color: var(--red); }
 .verdict { margin-right: 4px; }
+
+.warn-block { border-color: var(--orange); background: #fffdf7; }
+.warn-block h2 { color: var(--orange); }
 
 /* ---------- buttons ---------- */
 .tabs { display: flex; gap: 4px; margin: 18px 0; flex-wrap: wrap; }

--- a/web/templates/config.html
+++ b/web/templates/config.html
@@ -8,13 +8,36 @@
 <p class="muted">Config: {{ cfg.config_path }} · org: {{ cfg.org or "—" }}
   · interval: {{ cfg.interval }}m · drafts: {{ cfg.drafts }}
   · post comment: {{ cfg.post_comment }}</p>
+{% if cfg.unreachable %}
+<div class="config-block warn-block">
+  <h2>{{ cfg.unreachable|length }} repo{{ 's' if cfg.unreachable|length != 1 }} cannot be reached</h2>
+  <p class="muted">GitHub answers 404 both for a repo that is gone and for one
+    this token cannot see, so these are either deleted, renamed, or private to
+    another account. The poller retries them every pass.</p>
+  <p class="muted">{{ cfg.unreachable|join(", ") }}</p>
+  <button class="tab-btn danger" onclick="removeUnreachable({{ cfg.unreachable|tojson }})">
+    Remove all {{ cfg.unreachable|length }}</button>
+</div>
+{% endif %}
+
 <table class="table">
-  <thead><tr><th>Repo</th><th>Mode</th><th>Actions</th></tr></thead>
+  <thead><tr><th>Repo</th><th>Mode</th><th>Reachable</th><th>Actions</th></tr></thead>
   <tbody>
   {% for r in cfg.repos %}
     <tr class="{{ 'unlisted' if r.mode == 'unlisted' }}">
       <td>{{ r.name }}</td>
       <td><span class="verdict v-{{ r.mode }}">{{ r.mode }}</span></td>
+      <td>
+        {% if r.mode == 'unlisted' %}
+          <span class="muted">—</span>
+        {% elif r.check.status == 'ok' %}
+          <span class="verdict v-pass">ok</span>
+        {% elif r.check.status == 'unknown' %}
+          <span class="verdict v-unverified" title="{{ r.check.detail }}">unverified</span>
+        {% else %}
+          <span class="verdict v-fail" title="{{ r.check.detail }}">{{ r.check.status }}</span>
+        {% endif %}
+      </td>
       <td>
         {% if r.mode == 'unlisted' %}
           <button class="tab-btn" onclick="setMode('{{ r.name }}','auto')">Enable auto</button>
@@ -25,14 +48,14 @@
       </td>
     </tr>
   {% else %}
-    <tr><td colspan="3" class="empty">No repos configured</td></tr>
+    <tr><td colspan="4" class="empty">No repos configured</td></tr>
   {% endfor %}
   </tbody>
 </table>
 <form class="add-form" onsubmit="addRepo(event)">
   <input class="add-input" id="new-repo" placeholder="owner/repo or repo name">
   <button class="tab-btn" type="submit">Add repo</button>
-  <button class="tab-btn" type="button" onclick="location.reload()">Refresh</button>
+  <button class="tab-btn" type="button" onclick="location.href='/config?recheck=1'">Re-check repos</button>
 </form>
 {% endif %}
 
@@ -43,7 +66,19 @@ async function postJson(url, body) {
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify(body)
   });
-  if (!r.ok) { alert((await r.json()).detail || "error"); return; }
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) { alert(data.detail || "error"); return; }
+  if (data.warning) alert("Added, but " + data.warning);
+  location.reload();
+}
+
+async function removeUnreachable(names) {
+  if (!confirm(`Remove ${names.length} unreachable repo(s) from autoreview.yml?
+
+` + names.join("\n"))) return;
+  for (const name of names) {
+    await fetch(`/api/config/repos/${encodeURIComponent(name)}`, {method: "DELETE"});
+  }
   location.reload();
 }
 function setMode(repo, mode) { postJson(`/api/config/repos/${encodeURIComponent(repo)}/mode`, {mode}); }


### PR DESCRIPTION
Nothing ever checked a repo name. A typo — or a bare name resolved against the wrong `org` — became a permanent entry in `autoreview.yml` that the poller retried every pass and that the dashboard rendered as a real repo with "No reviews yet", indistinguishable from one that simply has no open PRs.

The local config had **seven** such entries — bare names that resolved against an `org` those repos do not belong to:

```
missing    <bare-name-1>          # resolved to <org>/<bare-name-1>, which does not exist
missing    <bare-name-2>
missing    <bare-name-3>
missing    <bare-name-4>
ok         <org>/deepseek-harness-pr-review
ok         <org>/<repo>
missing    <org>/<typo>
missing    <bare-name-5>
missing    <other-org>/<repo>
```

(Real names redacted — the point is the shape: 7 of 9 entries pointed at nothing.)

## Checking

`src/repo_check.py` resolves a name through `gh api repos/{owner}/{repo}` and sorts the outcome:

| status | meaning |
|---|---|
| `ok` | resolves |
| `missing` | 404 — gone, renamed, or private to this token |
| `forbidden` | 401/403 — seen but refused (token scope, SAML) |
| `unknown` | the check itself could not run |

GitHub answers 404 both for a repo that does not exist and for a private one the token cannot see, and does not tell the two apart — so the message doesn't either. `unknown` is deliberately never actionable: a network blip must not block a legitimate repo or justify deleting one.

## Adding

- **Web** — `POST /api/config/repos` refuses `missing`/`forbidden` with the reason, and the name never reaches the config file. On `unknown` it adds but returns a warning the UI shows.
- **CLI** — `--add-repo` does the same, with `--force-add` to override.

## Finding the dead ones

- **`/config`** gains a Reachable column, a banner naming the unreachable entries, and a **Remove all N** button behind a confirm. Results cache for 5 minutes since the page reloads after every edit; **Re-check repos** busts the cache.
- **`autoreview --check-repos`** prints the same report and exits 1 when any are unreachable, so it can gate a script.

## Note

This does not touch anyone's `autoreview.yml` — the seven entries above are still there, now flagged with a one-click removal. Clearing them is the operator's call.

257 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
