### PR TITLE
fix: a bare repo key belongs to the configured org, not to any owner

### DIFF
--- a/src/autoreview_config.py
+++ b/src/autoreview_config.py
@@ -84,12 +84,44 @@ def _write_atomic(path: Path, cfg: dict) -> None:
     os.replace(tmp, path)
 
 
+def repo_mode(cfg: dict, owner: str, repo: str) -> str | None:
+    """Configured mode for owner/repo, or None if it is not configured.
+
+    A bare key like `erp` means `<org>/erp` and nothing else. Matching it
+    against any owner made the dashboard show AUTO for nexpeakcore/erp on the
+    strength of a `erp: auto` entry that auto_repos() resolves to sample-org/erp
+    — a different repo the poller would never review.
+    """
+    full = f"{owner}/{repo}"
+    if full in cfg.get("repos", {}):
+        return cfg["repos"][full]
+    if cfg.get("org") and cfg["org"] == owner:
+        return cfg["repos"].get(repo)
+    return None
+
+
+def resolve_key(cfg: dict, name: str) -> str:
+    """The key in cfg['repos'] that `name` refers to, existing or to be created.
+
+    Keeps an edit on owner/repo from creating a duplicate entry when the same
+    repo is already configured under its bare name.
+    """
+    repos = cfg.get("repos", {})
+    if name in repos:
+        return name
+    if "/" in name:
+        owner, _, repo = name.partition("/")
+        if cfg.get("org") and cfg["org"] == owner and repo in repos:
+            return repo
+    return name
+
+
 def set_repo_mode(path: Path, repo: str, mode: str) -> dict:
     """Add or change mode for a repo. Returns the updated config."""
     if mode not in ("auto", "manual"):
         raise ValueError(f"mode must be auto|manual: {mode!r}")
     cfg = load_config(path)
-    cfg["repos"][repo] = mode
+    cfg["repos"][resolve_key(cfg, repo)] = mode
     _write_atomic(path, cfg)
     return cfg
 

--- a/tests/test_agent_pool.py
+++ b/tests/test_agent_pool.py
@@ -94,3 +94,25 @@ def test_slot_root_can_be_overridden(tmp_path, monkeypatch):
     monkeypatch.setenv("HARNESS_SLOT_ROOT", str(tmp_path))
     assert default_root() == tmp_path
     assert slot_dir() == tmp_path / ".agent-slots"
+
+
+def test_a_real_review_and_a_test_run_can_be_kept_apart(tmp_path, monkeypatch):
+    """HARNESS_SLOT_ROOT exists so a test suite never draws on the live budget.
+
+    The pool is rooted at the install directory on purpose — a cap tied to the
+    CWD is not global — which also means chdir cannot isolate anything from it.
+    """
+    from src.agent_pool import acquire_slot, default_root
+
+    production = tmp_path / "prod"
+    monkeypatch.setenv("HARNESS_SLOT_ROOT", str(production))
+    assert default_root() == production
+
+    # Fill the "production" pool completely.
+    held = [acquire_slot(f"live-{i}", limit=2) for i in range(2)]
+    assert len(held) == 2
+
+    # A different root is unaffected by it.
+    monkeypatch.setenv("HARNESS_SLOT_ROOT", str(tmp_path / "isolated"))
+    free = acquire_slot("test", limit=2, timeout=0)
+    assert free.parent.parent == tmp_path / "isolated"

--- a/tests/test_autoreview_config.py
+++ b/tests/test_autoreview_config.py
@@ -174,3 +174,59 @@ def test_max_agents_travels_to_the_review_subprocess(tmp_path, monkeypatch):
     run_review("o", "r", 1, session_root=tmp_path,
                log_path=tmp_path / "l.log", max_agents=6)
     assert seen["HARNESS_MAX_AGENTS"] == "6"
+
+
+def test_bare_key_belongs_to_the_configured_org_only():
+    """`erp: auto` means <org>/erp — not every owner's repo called erp.
+
+    The dashboard used to fall back to a bare-name lookup with no owner check,
+    so /repos/nexpeakcore/erp showed AUTO on the strength of an entry that
+    auto_repos() resolves to sample-org/erp — a repo the poller never touches.
+    """
+    from src.autoreview_config import repo_mode
+
+    cfg = {"org": "sample-org", "repos": {"erp": "auto",
+                                          "nexpeakcore/erp-desktop": "manual"}}
+    assert repo_mode(cfg, "sample-org", "erp") == "auto"
+    assert repo_mode(cfg, "nexpeakcore", "erp") is None
+    assert repo_mode(cfg, "nexpeakcore", "erp-desktop") == "manual"
+    assert repo_mode(cfg, "other", "nothing") is None
+
+
+def test_bare_key_matches_nothing_when_no_org_is_set():
+    from src.autoreview_config import repo_mode
+
+    cfg = {"org": "", "repos": {"erp": "auto"}}
+    assert repo_mode(cfg, "anyone", "erp") is None
+
+
+def test_repo_mode_agrees_with_auto_repos():
+    """The badge and the poller must not disagree about what is auto."""
+    from src.autoreview_config import auto_repos, repo_mode
+
+    cfg = {"org": "sample-org",
+           "repos": {"erp": "auto", "nexpeakcore/api": "auto", "x": "manual"}}
+    for owner, repo in auto_repos(cfg):
+        assert repo_mode(cfg, owner, repo) == "auto"
+    assert repo_mode(cfg, "nexpeakcore", "erp") is None
+    assert ("nexpeakcore", "erp") not in auto_repos(cfg)
+
+
+def test_set_mode_updates_the_bare_key_instead_of_duplicating(tmp_path):
+    from src.autoreview_config import load_config, set_repo_mode
+
+    path = tmp_path / "autoreview.yml"
+    path.write_text("org: sample-org\nrepos:\n  erp: auto\n")
+    set_repo_mode(path, "sample-org/erp", "manual")
+    repos = load_config(path)["repos"]
+    assert repos == {"erp": "manual"}          # no second entry for the same repo
+
+
+def test_set_mode_for_another_owner_creates_its_own_key(tmp_path):
+    from src.autoreview_config import load_config, set_repo_mode
+
+    path = tmp_path / "autoreview.yml"
+    path.write_text("org: sample-org\nrepos:\n  erp: auto\n")
+    set_repo_mode(path, "nexpeakcore/erp", "auto")
+    repos = load_config(path)["repos"]
+    assert repos == {"erp": "auto", "nexpeakcore/erp": "auto"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -548,3 +548,58 @@ def test_pr_page_never_reviewed_still_says_not_reviewed(tmp_path, monkeypatch):
     assert resp.status_code == 200
     assert "Not reviewed yet" in resp.text
     assert "Failed · interrupted" not in resp.text
+
+
+def _config_client(tmp_path, monkeypatch, body):
+    cfg_path = tmp_path / "autoreview.yml"
+    cfg_path.write_text(body)
+    monkeypatch.setenv("AUTOREVIEW_CONFIG", str(cfg_path))
+    monkeypatch.setenv("DSH_SESSION_ROOT", str(tmp_path / "sessions"))
+    monkeypatch.setattr("src.gh.run_gh", lambda args, **kw: [])
+    return TestClient(app), cfg_path
+
+
+def test_repo_page_does_not_claim_auto_from_another_owners_bare_key(tmp_path, monkeypatch):
+    """/repos/nexpeakcore/erp must not read `erp: auto`, which means sample-org/erp."""
+    client, _ = _config_client(
+        tmp_path, monkeypatch,
+        "org: sample-org\ndefault_mode: manual\nrepos:\n  erp: auto\n")
+
+    html = client.get("/repos/nexpeakcore/erp").text
+    assert "MANUAL (default)" in html
+
+    assert "AUTO" in client.get("/repos/sample-org/erp").text
+
+
+def test_toggling_mode_from_a_repo_page_targets_that_owner(tmp_path, monkeypatch):
+    from src.autoreview_config import load_config as load_acfg
+
+    client, cfg_path = _config_client(
+        tmp_path, monkeypatch, "org: sample-org\nrepos:\n  erp: auto\n")
+
+    r = client.post("/api/config/repos/nexpeakcore%2Ferp/mode", json={"mode": "auto"})
+    assert r.status_code == 200
+    repos = load_acfg(cfg_path)["repos"]
+    # The other owner's entry is untouched; a new, explicit one is created.
+    assert repos == {"erp": "auto", "nexpeakcore/erp": "auto"}
+
+
+def test_config_routes_accept_owner_slash_repo_keys(tmp_path, monkeypatch):
+    """Config keys contain slashes; a single-segment route 404'd on all of them."""
+    from src.autoreview_config import load_config as load_acfg
+
+    client, cfg_path = _config_client(
+        tmp_path, monkeypatch,
+        "org: sample-org\nrepos:\n  nexpeakcore/erp-desktop: auto\n  erp: auto\n")
+
+    r = client.post("/api/config/repos/nexpeakcore%2Ferp-desktop/mode",
+                    json={"mode": "manual"})
+    assert r.status_code == 200
+    assert load_acfg(cfg_path)["repos"]["nexpeakcore/erp-desktop"] == "manual"
+
+    assert client.delete("/api/config/repos/nexpeakcore%2Ferp-desktop").status_code == 200
+    assert "nexpeakcore/erp-desktop" not in load_acfg(cfg_path)["repos"]
+
+    # Bare keys keep working.
+    assert client.delete("/api/config/repos/erp").status_code == 200
+    assert load_acfg(cfg_path)["repos"] == {}

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,6 +3,17 @@ import subprocess
 
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def isolated_agent_slots(tmp_path, monkeypatch):
+    """Give every test its own agent-slot pool.
+
+    The pool is deliberately rooted at the install directory rather than the
+    CWD, so chdir does not isolate it: without this the suite draws from the
+    same budget as a running review and either throttles or blocks on it.
+    """
+    monkeypatch.setenv("HARNESS_SLOT_ROOT", str(tmp_path / "slots"))
+
 from src.verify import (build_claims_prompt, build_docs_prompt,
                         build_impact_prompt, parse_findings, setup_workspace)
 
@@ -285,7 +296,6 @@ def _concurrency_probe(payloads, hold=0.15):
 def test_axes_actually_run_in_parallel(tmp_path, monkeypatch):
     """The point of fan-out: the axes must overlap, not queue behind each other."""
     monkeypatch.setenv("HARNESS_MAX_AGENTS", "4")
-    monkeypatch.chdir(tmp_path)          # keep .agent-slots out of the repo
     ws, sd = tmp_path / "ws", tmp_path / "sd"
     ws.mkdir()
 
@@ -300,7 +310,6 @@ def test_axes_actually_run_in_parallel(tmp_path, monkeypatch):
 def test_global_cap_throttles_the_fan_out(tmp_path, monkeypatch):
     """max_agents is a system-wide budget, so it must bound one review too."""
     monkeypatch.setenv("HARNESS_MAX_AGENTS", "2")
-    monkeypatch.chdir(tmp_path)
     ws, sd = tmp_path / "ws", tmp_path / "sd"
     ws.mkdir()
 

--- a/web/server.py
+++ b/web/server.py
@@ -10,6 +10,7 @@ from fastapi.templating import Jinja2Templates
 
 from src.autoreview_config import load_config as load_autoreview_config
 from src.autoreview_config import auto_repos, list_repos, remove_repo, set_repo_mode
+from src.autoreview_config import repo_mode as config_repo_mode
 from src.config import load_config
 from src.review_proc import EXIT_TIMEOUT, run_review
 from web import metrics
@@ -110,13 +111,9 @@ def repo_page(request: Request, owner: str, repo: str):
             from src.autoreview_config import load_config as load_acfg
 
             acfg = load_acfg(cfg_path)
-            org = acfg.get("org", "")
-            key = repo if "/" in repo else f"{owner}/{repo}"
-            repo_mode = acfg["repos"].get(key) or acfg["repos"].get(repo)
-            if repo_mode is None and org and org == owner:
-                repo_mode = acfg["repos"].get(repo)
-            if repo_mode is not None:
-                mode_configured = True
+            configured = config_repo_mode(acfg, owner, repo)
+            if configured is not None:
+                repo_mode, mode_configured = configured, True
             else:
                 repo_mode = acfg.get("default_mode", "manual")
         except (ValueError, OSError):
@@ -209,7 +206,7 @@ def api_config():
     }
 
 
-@app.post("/api/config/repos/{repo}/mode")
+@app.post("/api/config/repos/{repo:path}/mode")
 def api_set_mode(repo: str, payload: dict):
     path = _config_path()
     if not path.exists():
@@ -244,7 +241,7 @@ def api_add_repo(payload: dict):
     return {"ok": True, "repo": repo}
 
 
-@app.delete("/api/config/repos/{repo}")
+@app.delete("/api/config/repos/{repo:path}")
 def api_remove_repo(repo: str):
     path = _config_path()
     if not path.exists():

--- a/web/templates/repo.html
+++ b/web/templates/repo.html
@@ -9,7 +9,7 @@
   <button class="tab-btn review-btn mode-toggle"
           onclick="toggleMode(this)"
           data-mode="{{ repo.mode }}"
-          data-owner="{{ repo.owner }}" data-repo="{{ repo.repo }}"
+          data-owner="{{ repo.owner }}" data-repo="{{ repo.owner }}/{{ repo.repo }}"
           {% if repo.mode == 'auto' %}data-next="manual"{% else %}data-next="auto"{% endif %}>
     Switch to {% if repo.mode == 'auto' %}MANUAL{% else %}AUTO{% endif %}
   </button>


### PR DESCRIPTION
`/repos/acme/api` shows **AUTO** but is never auto-reviewed.

## Why

The config has no `acme/api` entry. It has `api: auto`, and `auto_repos()` resolves a bare key against `org: sample-org` → `sample-org/api`, a different repo. But the repo page's lookup was:

```python
repo_mode = acfg["repos"].get(key) or acfg["repos"].get(repo)
if repo_mode is None and org and org == owner:   # correct — and unreachable
    repo_mode = acfg["repos"].get(repo)
```

The unguarded `or` already answered, so the owner check on the next line never ran. The dashboard promised auto-review for a repo the poller would never visit:

```
auto_repos() actually yields:
    acme/deepseek-harness-pr-review
    sample-org/api, sample-org/docs, sample-org/billing, …
    acme/sample-api, acme/billing
                                    ^ no acme/api anywhere
```

`repo_mode()` in `autoreview_config` is now the single owner-aware lookup, with a test asserting it agrees with `auto_repos()` — the badge and the poller cannot drift apart again.

## Two more bugs found on the way

**The mode toggle configured the wrong repo.** The repo page posted the bare name, so "Switch to AUTO" on `/repos/acme/api` wrote `api: auto` — configuring `sample-org/api`. That is very likely how the bare entries got into the config in the first place. It now posts `owner/repo`, and `resolve_key()` updates an existing bare entry instead of duplicating it.

**Those requests 404'd regardless.** `/api/config/repos/{repo}` matches a single path segment, so every button on `/config` was broken for any key containing a slash — `acme/billing`, `sample-org/sample-api`. Now `{repo:path}`.

## Test isolation this exposed

The agent-slot pool is rooted at the install directory on purpose (a cap tied to CWD is not global), which means `monkeypatch.chdir` never isolated the fan-out tests from it. **The suite draws on the same budget as production reviews.** With a live `python -m src.run` holding 3 of 4 slots, the concurrency tests saw peak 1 instead of 4, and the cap-2 test blocked until that review finished — a two-minute hang that looked like a deadlock. Tests now set `HARNESS_SLOT_ROOT`.

## Note

This does not explain everything the operator saw: **the poller was not running at all**, so nothing was being auto-reviewed regardless of config. This fixes the config lying about it.

247 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
