### PR TITLE
chore: scrub internal repo names out of tests and docstrings

### DIFF
--- a/src/autoreview_config.py
+++ b/src/autoreview_config.py
@@ -87,9 +87,9 @@ def _write_atomic(path: Path, cfg: dict) -> None:
 def repo_mode(cfg: dict, owner: str, repo: str) -> str | None:
     """Configured mode for owner/repo, or None if it is not configured.
 
-    A bare key like `erp` means `<org>/erp` and nothing else. Matching it
-    against any owner made the dashboard show AUTO for nexpeakcore/erp on the
-    strength of a `erp: auto` entry that auto_repos() resolves to sample-org/erp
+    A bare key like `api` means `<org>/api` and nothing else. Matching it
+    against any owner made the dashboard show AUTO for acme/api on the
+    strength of a `api: auto` entry that auto_repos() resolves to sample-org/api
     — a different repo the poller would never review.
     """
     full = f"{owner}/{repo}"

--- a/tests/test_autoreview_config.py
+++ b/tests/test_autoreview_config.py
@@ -177,27 +177,27 @@ def test_max_agents_travels_to_the_review_subprocess(tmp_path, monkeypatch):
 
 
 def test_bare_key_belongs_to_the_configured_org_only():
-    """`erp: auto` means <org>/erp — not every owner's repo called erp.
+    """`api: auto` means <org>/api — not every owner's repo called api.
 
     The dashboard used to fall back to a bare-name lookup with no owner check,
-    so /repos/nexpeakcore/erp showed AUTO on the strength of an entry that
-    auto_repos() resolves to sample-org/erp — a repo the poller never touches.
+    so /repos/acme/api showed AUTO on the strength of an entry that
+    auto_repos() resolves to sample-org/api — a repo the poller never touches.
     """
     from src.autoreview_config import repo_mode
 
-    cfg = {"org": "sample-org", "repos": {"erp": "auto",
-                                          "nexpeakcore/erp-desktop": "manual"}}
-    assert repo_mode(cfg, "sample-org", "erp") == "auto"
-    assert repo_mode(cfg, "nexpeakcore", "erp") is None
-    assert repo_mode(cfg, "nexpeakcore", "erp-desktop") == "manual"
+    cfg = {"org": "sample-org", "repos": {"api": "auto",
+                                          "acme/billing": "manual"}}
+    assert repo_mode(cfg, "sample-org", "api") == "auto"
+    assert repo_mode(cfg, "acme", "api") is None
+    assert repo_mode(cfg, "acme", "billing") == "manual"
     assert repo_mode(cfg, "other", "nothing") is None
 
 
 def test_bare_key_matches_nothing_when_no_org_is_set():
     from src.autoreview_config import repo_mode
 
-    cfg = {"org": "", "repos": {"erp": "auto"}}
-    assert repo_mode(cfg, "anyone", "erp") is None
+    cfg = {"org": "", "repos": {"api": "auto"}}
+    assert repo_mode(cfg, "anyone", "api") is None
 
 
 def test_repo_mode_agrees_with_auto_repos():
@@ -205,28 +205,28 @@ def test_repo_mode_agrees_with_auto_repos():
     from src.autoreview_config import auto_repos, repo_mode
 
     cfg = {"org": "sample-org",
-           "repos": {"erp": "auto", "nexpeakcore/api": "auto", "x": "manual"}}
+           "repos": {"api": "auto", "acme/billing": "auto", "x": "manual"}}
     for owner, repo in auto_repos(cfg):
         assert repo_mode(cfg, owner, repo) == "auto"
-    assert repo_mode(cfg, "nexpeakcore", "erp") is None
-    assert ("nexpeakcore", "erp") not in auto_repos(cfg)
+    assert repo_mode(cfg, "acme", "api") is None
+    assert ("acme", "api") not in auto_repos(cfg)
 
 
 def test_set_mode_updates_the_bare_key_instead_of_duplicating(tmp_path):
     from src.autoreview_config import load_config, set_repo_mode
 
     path = tmp_path / "autoreview.yml"
-    path.write_text("org: sample-org\nrepos:\n  erp: auto\n")
-    set_repo_mode(path, "sample-org/erp", "manual")
+    path.write_text("org: sample-org\nrepos:\n  api: auto\n")
+    set_repo_mode(path, "sample-org/api", "manual")
     repos = load_config(path)["repos"]
-    assert repos == {"erp": "manual"}          # no second entry for the same repo
+    assert repos == {"api": "manual"}          # no second entry for the same repo
 
 
 def test_set_mode_for_another_owner_creates_its_own_key(tmp_path):
     from src.autoreview_config import load_config, set_repo_mode
 
     path = tmp_path / "autoreview.yml"
-    path.write_text("org: sample-org\nrepos:\n  erp: auto\n")
-    set_repo_mode(path, "nexpeakcore/erp", "auto")
+    path.write_text("org: sample-org\nrepos:\n  api: auto\n")
+    set_repo_mode(path, "acme/api", "auto")
     repos = load_config(path)["repos"]
-    assert repos == {"erp": "auto", "nexpeakcore/erp": "auto"}
+    assert repos == {"api": "auto", "acme/api": "auto"}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -586,10 +586,10 @@ def test_add_repo_refuses_one_github_cannot_see(tmp_path, monkeypatch):
 
 def test_add_repo_accepts_a_reachable_one(tmp_path, monkeypatch):
     client, cfg_path = _cfg_client(tmp_path, monkeypatch, _gh_with_missing([]))
-    r = client.post("/api/config/repos", json={"repo": "nexpeakcore/erp"})
+    r = client.post("/api/config/repos", json={"repo": "acme/api"})
     assert r.status_code == 200
     assert r.json()["warning"] is None
-    assert load_config(cfg_path)["repos"]["nexpeakcore/erp"] == "auto"
+    assert load_config(cfg_path)["repos"]["acme/api"] == "auto"
 
 
 def test_add_repo_survives_an_unverifiable_check(tmp_path, monkeypatch):
@@ -649,28 +649,28 @@ def test_repo_check_results_are_cached_until_rechecked(tmp_path, monkeypatch):
 
 
 def test_repo_page_does_not_claim_auto_from_another_owners_bare_key(tmp_path, monkeypatch):
-    """/repos/nexpeakcore/erp must not read `erp: auto`, which means sample-org/erp."""
+    """/repos/acme/api must not read `api: auto`, which means sample-org/api."""
     client, _ = _cfg_client(
         tmp_path, monkeypatch, lambda args, **kw: [],
-        "org: sample-org\ndefault_mode: manual\nrepos:\n  erp: auto\n")
+        "org: sample-org\ndefault_mode: manual\nrepos:\n  api: auto\n")
 
-    html = client.get("/repos/nexpeakcore/erp").text
+    html = client.get("/repos/acme/api").text
     assert "MANUAL (default)" in html
 
-    assert "AUTO" in client.get("/repos/sample-org/erp").text
+    assert "AUTO" in client.get("/repos/sample-org/api").text
 
 
 def test_toggling_mode_from_a_repo_page_targets_that_owner(tmp_path, monkeypatch):
     from src.autoreview_config import load_config as load_acfg
 
     client, cfg_path = _cfg_client(
-        tmp_path, monkeypatch, lambda args, **kw: [], "org: sample-org\nrepos:\n  erp: auto\n")
+        tmp_path, monkeypatch, lambda args, **kw: [], "org: sample-org\nrepos:\n  api: auto\n")
 
-    r = client.post("/api/config/repos/nexpeakcore%2Ferp/mode", json={"mode": "auto"})
+    r = client.post("/api/config/repos/acme%2Fapi/mode", json={"mode": "auto"})
     assert r.status_code == 200
     repos = load_acfg(cfg_path)["repos"]
     # The other owner's entry is untouched; a new, explicit one is created.
-    assert repos == {"erp": "auto", "nexpeakcore/erp": "auto"}
+    assert repos == {"api": "auto", "acme/api": "auto"}
 
 
 def test_config_routes_accept_owner_slash_repo_keys(tmp_path, monkeypatch):
@@ -679,16 +679,16 @@ def test_config_routes_accept_owner_slash_repo_keys(tmp_path, monkeypatch):
 
     client, cfg_path = _cfg_client(
         tmp_path, monkeypatch, lambda args, **kw: [],
-        "org: sample-org\nrepos:\n  nexpeakcore/erp-desktop: auto\n  erp: auto\n")
+        "org: sample-org\nrepos:\n  acme/billing: auto\n  api: auto\n")
 
-    r = client.post("/api/config/repos/nexpeakcore%2Ferp-desktop/mode",
+    r = client.post("/api/config/repos/acme%2Fbilling/mode",
                     json={"mode": "manual"})
     assert r.status_code == 200
-    assert load_acfg(cfg_path)["repos"]["nexpeakcore/erp-desktop"] == "manual"
+    assert load_acfg(cfg_path)["repos"]["acme/billing"] == "manual"
 
-    assert client.delete("/api/config/repos/nexpeakcore%2Ferp-desktop").status_code == 200
-    assert "nexpeakcore/erp-desktop" not in load_acfg(cfg_path)["repos"]
+    assert client.delete("/api/config/repos/acme%2Fbilling").status_code == 200
+    assert "acme/billing" not in load_acfg(cfg_path)["repos"]
 
     # Bare keys keep working.
-    assert client.delete("/api/config/repos/erp").status_code == 200
+    assert client.delete("/api/config/repos/api").status_code == 200
     assert load_acfg(cfg_path)["repos"] == {}


### PR DESCRIPTION
Security review of what this session pushed. **No credentials leaked.** Two private repo names did.

## Clean

Full-history scan (every blob in every commit) for API keys, GitHub tokens, AWS keys, private keys, Slack/Google tokens, and secret-shaped assignments (`API_KEY = "..."`, `SECRET: "..."`): **nothing**. `.env` is gitignored; `.env.example` holds only `sk-your-key-here`. `autoreview.yml` is gitignored, and the versions that were tracked before `766cdc3` contain no credentials either. Only `sessions/demo/app/` is tracked from `sessions/` — properly anonymized (`demo/app`, `alice-dev`, `carol-eng`), with empty diff patches, so no private source code shipped.

## The leak

`58927c3 chore: anonymize test fixtures, clean internal repo names` deliberately scrubbed internal names. This session put two back, in a **public** repo:

| name | introduced in | where |
|---|---|---|
| `nexpeakcore/erp` | #12, #14, #15 | `src/autoreview_config.py:90-92`, `tests/test_autoreview_config.py`, `tests/test_server.py` |
| `nexpeakcore/erp-desktop` | #15 | `tests/test_autoreview_config.py:189`, `tests/test_server.py:682-690` |

Both are private repositories. They came from the operator's local `autoreview.yml` while debugging a real config problem and became test fixtures and a docstring example.

`admin-web` and `sample-app2` predate this session and stay — they read as generic placeholders, and are part of the existing anonymized fixture set.

## Fix

Renamed to `acme/api` and `acme/billing`, matching the placeholder style already in use (`sample-org`, `sample-app`, `demo/app`).

Two spots needed hand fixing, not sed: the URL-encoded forms (`acme%2Ferp-desktop`) contain no slash to match, and collapsing two fixtures onto one owner made `test_repo_mode_agrees_with_auto_repos` assert nothing — the explicit entry must belong to a *different* owner than the bare key or the test proves nothing.

Also redacted the PR bodies of #14 and #15, which listed the operator's repo inventory and which entries resolve.

## What this does NOT fix

The names remain in git history, reachable in `0842900`, `f465af7`, `1c9e05e`, and in this session's PR comment history. Rewriting public history (force-push over 5 merged PRs) is a separate call — see the PR discussion.

269 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)