### PR TITLE
fix: gh --paginate emits one JSON document per page, not one overall

### DIFF
--- a/src/gh.py
+++ b/src/gh.py
@@ -7,6 +7,41 @@ def _run_gh_impl(args: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(["gh", *args], capture_output=True, text=True)
 
 
+def parse_json_stream(text: str):
+    """Parse gh's stdout, which is not always a single JSON document.
+
+    `gh api --paginate` emits ONE document per page, so any response past the
+    100-item page size arrives as `[...]\\n[...]` — two valid documents, and not
+    valid JSON together. It stayed invisible for a year because every call site
+    happened to stay under 100: PR #942 grew from 87 changed files to 120 and
+    the review died in phase 1 with "Extra data: line 2 column 1".
+
+    `--slurp` would also fix it, but it returns pages nested (`[[...],[...]]`)
+    and gh rejects it alongside `--jq`, so the seam is better handled here:
+    one place, no flag juggling, no gh version floor.
+
+    Single-document output (the overwhelmingly common case) decodes on the
+    first pass. Multiple list documents are pages of one collection and are
+    concatenated; anything else is returned as the list of documents.
+    """
+    decoder = _json.JSONDecoder()
+    docs, idx, end = [], 0, len(text)
+    while idx < end:
+        while idx < end and text[idx] in " \t\r\n":
+            idx += 1
+        if idx >= end:
+            break
+        doc, idx = decoder.raw_decode(text, idx)
+        docs.append(doc)
+    if not docs:
+        raise _json.JSONDecodeError("no JSON document in output", text or "", 0)
+    if len(docs) == 1:
+        return docs[0]
+    if all(isinstance(d, list) for d in docs):
+        return [item for page in docs for item in page]
+    return docs
+
+
 def run_gh(args: list[str], *, json: bool = True) -> dict | list:
     proc = _run_gh_impl(args + (["--jq", "."] if json else []))
     if proc.returncode != 0:
@@ -14,7 +49,7 @@ def run_gh(args: list[str], *, json: bool = True) -> dict | list:
     if not json:
         return proc.stdout
     try:
-        return _json.loads(proc.stdout)
+        return parse_json_stream(proc.stdout)
     except _json.JSONDecodeError as e:
         raise RuntimeError(
             f"gh api returned invalid JSON: {e}. stdout={proc.stdout[:200]!r}"

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -43,3 +43,61 @@ def test_gh_available(monkeypatch):
 
     monkeypatch.setattr("src.gh.subprocess.run", fake_run)
     assert gh_available() is True
+
+
+def _gh_returning(stdout):
+    def fake_run(cmd, capture_output, text):
+        return type("R", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+    return fake_run
+
+
+def test_paginated_pages_are_concatenated(monkeypatch):
+    """`gh api --paginate` emits one JSON document PER PAGE, not one overall.
+
+    A PR that grows past 100 changed files turns the response into
+    `[...]\n[...]` — two valid documents, invalid JSON together. This crashed
+    phase 1 with "Extra data: line 2 column 1" on a 120-file PR.
+    """
+    page1 = json.dumps([{"filename": f"f{i}.py"} for i in range(100)])
+    page2 = json.dumps([{"filename": f"f{i}.py"} for i in range(100, 120)])
+    monkeypatch.setattr("src.gh.subprocess.run", _gh_returning(f"{page1}\n{page2}"))
+
+    out = run_gh(["api", "repos/x/y/pulls/1/files", "--paginate"])
+    assert len(out) == 120
+    assert out[0]["filename"] == "f0.py"
+    assert out[-1]["filename"] == "f119.py"
+
+
+def test_three_pages(monkeypatch):
+    stdout = "\n".join(json.dumps([i]) for i in range(3))
+    monkeypatch.setattr("src.gh.subprocess.run", _gh_returning(stdout))
+    assert run_gh(["api", "x", "--paginate"]) == [0, 1, 2]
+
+
+def test_single_page_is_unchanged(monkeypatch):
+    """The common case must not be reshaped by the multi-page handling."""
+    monkeypatch.setattr("src.gh.subprocess.run",
+                        _gh_returning(json.dumps([{"a": 1}, {"a": 2}])))
+    assert run_gh(["api", "x", "--paginate"]) == [{"a": 1}, {"a": 2}]
+
+    monkeypatch.setattr("src.gh.subprocess.run", _gh_returning(json.dumps({"a": 1})))
+    assert run_gh(["api", "x"]) == {"a": 1}
+
+
+def test_non_list_documents_are_not_flattened(monkeypatch):
+    """Only pages of a collection concatenate; separate objects stay separate."""
+    monkeypatch.setattr("src.gh.subprocess.run",
+                        _gh_returning('{"a": 1}\n{"b": 2}'))
+    assert run_gh(["api", "x", "--paginate"]) == [{"a": 1}, {"b": 2}]
+
+
+def test_whitespace_and_blank_lines_between_pages(monkeypatch):
+    monkeypatch.setattr("src.gh.subprocess.run",
+                        _gh_returning('  [1]  \n\n\n  [2]\n  '))
+    assert run_gh(["api", "x", "--paginate"]) == [1, 2]
+
+
+def test_truly_malformed_output_still_raises(monkeypatch):
+    monkeypatch.setattr("src.gh.subprocess.run", _gh_returning("[1] garbage"))
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        run_gh(["api", "x"])


### PR DESCRIPTION
## The crash

```
[1/5] snapshot — nexpeakcore/erp#942
Error: gh api returned invalid JSON: Extra data: line 2 column 1 (char 485681)
```

`gh api --paginate` concatenates pages, emitting **one JSON document per page**. Past the 100-item page size the response is `[...]\n[...]` — two valid documents, invalid JSON together. `json.loads` stops after the first and calls the second "extra data".

Reproduced against the live API:

```
document 1: list len=100
document 2: list len=20
=> 2 concatenated JSON documents
```

The PR had grown from 87 changed files to 120 and crossed the boundary. Nothing about the topped-up API balance or the review pipeline was involved — it never reached the model.

## Why it hid for a year

Every call site happened to stay under 100. Seven of them share `run_gh` and all had the same crash waiting:

| call site | trips at |
|---|---|
| `snapshot.build_snapshot` (files, commits) | a 100-file or 100-commit PR |
| `autoreview.fetch_open_prs`, `metrics.open_prs` | a repo with 100 open PRs |
| `synthesize.post_comment`, `find_report_comment` | a PR with 100 comments |
| `autoreview_config.list_repos` | an org with 100 repos |

## The fix

In `run_gh`, not at the call sites. `--slurp` also solves it, but it returns pages **nested** (`[[...],[...]]`) and gh rejects it alongside `--jq`:

```
$ gh api ... --paginate --slurp --jq .
parse error
```

so handling the seam in the parser keeps it to one place, with no flag juggling and no gh version floor.

- Single document (the common case): decoded on the first pass, returned unchanged.
- Multiple **list** documents: pages of one collection, concatenated.
- Anything else: returned as the list of documents rather than silently reshaped.
- Genuinely malformed output still raises `invalid JSON` with the same message.

## Verification

Live API, same PR that crashed:

```
files  : 120   (GitHub reports changed_files=120)
commits:  19   (GitHub reports commits=19)
```

The review that had been failing now clears phase 1 and proceeds.

275 tests pass (6 new, covering 2-page, 3-page, single-page-unchanged, non-list documents, whitespace between pages, and still-malformed output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)