### PR TITLE
fix: name model truncation instead of surfacing it as a JSON parse error

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -6,12 +6,14 @@ import urllib.request
 
 
 def chat(messages: list[dict], *, model: str, api_key: str, base_url: str,
-         max_tokens: int = 16384, retries: int = 3) -> str:
+         max_tokens: int = 49_152, retries: int = 3) -> str:
     """POST {base_url}/chat/completions. Retry up to `retries` times (timeout/429/5xx).
 
-    Default max_tokens 16384: deepseek-v4-flash is a reasoning model that spends
-    most of its tokens on reasoning_content before returning real content — 4096
-    is too small (finish_reason=length, empty content).
+    Default max_tokens 49152, matching the verify agent: deepseek-v4-flash is a
+    reasoning model that spends most of its budget on reasoning_content before
+    emitting any real content, so the cap is mostly consumed before the answer
+    starts. 4096 returned empty content; 16384 got a 120-file PR roughly 7.6K
+    characters into its claims JSON and cut it mid-string.
     """
     payload = json.dumps({
         "model": model,
@@ -30,9 +32,19 @@ def chat(messages: list[dict], *, model: str, api_key: str, base_url: str,
         try:
             with urllib.request.urlopen(req, timeout=120) as resp:
                 data = json.loads(resp.read().decode())
-                content = data["choices"][0]["message"]["content"]
+                choice = data["choices"][0]
+                content = choice["message"]["content"]
                 if content is None:
                     raise RuntimeError("chat returned null content")
+                # Truncation has to be named here. The caller only sees a
+                # half-written document, and json.loads reports it as
+                # "Unterminated string at line 146" — which reads like the model
+                # returned garbage rather than like it ran out of room.
+                if choice.get("finish_reason") == "length":
+                    raise RuntimeError(
+                        f"chat truncated: hit max_tokens={max_tokens} before "
+                        f"finishing (finish_reason=length, {len(content)} chars "
+                        f"returned). Raise max_tokens or send less input.")
                 return content
         except urllib.error.HTTPError as e:
             retryable = e.code >= 500 or e.code == 429

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -125,3 +125,59 @@ def test_chat_does_not_retry_401():
         assert _UnauthorizedHandler.count == 1
     finally:
         srv.shutdown()
+
+
+def _resp(content, finish_reason="stop"):
+    import json as _json
+
+    class R:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self):
+            return _json.dumps({"choices": [
+                {"message": {"content": content}, "finish_reason": finish_reason}
+            ]}).encode()
+    return R()
+
+
+def test_truncated_response_is_named_as_truncation(monkeypatch):
+    """finish_reason=length must not reach the caller as a JSON parse error.
+
+    A 120-file PR cut the claims JSON mid-string; the review died reporting
+    "Unterminated string at line 146", which reads like a broken model rather
+    than an exhausted token budget.
+    """
+    from src.llm import chat
+
+    monkeypatch.setattr("src.llm.urllib.request.urlopen",
+                        lambda req, timeout=0: _resp('[{"id": "C1", "text": "hal',
+                                                     finish_reason="length"))
+    with pytest.raises(RuntimeError, match=r"truncated: hit max_tokens=\d+"):
+        chat([{"role": "user", "content": "x"}],
+             model="m", api_key="k", base_url="http://x/v1")
+
+
+def test_complete_response_passes_through(monkeypatch):
+    from src.llm import chat
+
+    monkeypatch.setattr("src.llm.urllib.request.urlopen",
+                        lambda req, timeout=0: _resp("[]", finish_reason="stop"))
+    assert chat([{"role": "user", "content": "x"}],
+                model="m", api_key="k", base_url="http://x/v1") == "[]"
+
+
+def test_missing_finish_reason_is_not_treated_as_truncation(monkeypatch):
+    """Not every OpenAI-compatible server sends finish_reason."""
+    import json as _json
+
+    from src.llm import chat
+
+    class R:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self):
+            return _json.dumps({"choices": [{"message": {"content": "ok"}}]}).encode()
+
+    monkeypatch.setattr("src.llm.urllib.request.urlopen", lambda req, timeout=0: R())
+    assert chat([{"role": "user", "content": "x"}],
+                model="m", api_key="k", base_url="http://x/v1") == "ok"


### PR DESCRIPTION
> Re-opens #19, which GitHub auto-closed when its base branch was deleted during the #18 merge. Same commit, rebased onto main so it now carries only the `llm.py` change.

## The failure

The balance was topped up, #18 fixed the pagination crash, and the PR #942 review still failed — one phase later:

```
[1/5] snapshot — 120 files, 19 commits
[2/5] claims — reading the PR description
Error: invalid claims response (stated):
       Unterminated string starting at: line 146 column 15 (char 7634)
```

That reads like the model returned garbage. It didn't — it ran out of room. `chat()` never looked at `finish_reason`, so a response cut off at `max_tokens` reached the caller as a half-written document and `json.loads` reported the seam it stopped at.

## Naming the truncation

`chat()` now raises on `finish_reason == "length"`:

```
chat truncated: hit max_tokens=49152 before finishing
(finish_reason=length, 7634 chars returned). Raise max_tokens or send less input.
```

A server that omits `finish_reason` is still treated as complete, so other OpenAI-compatible endpoints are unaffected.

## Raising the cap

Default `max_tokens` 16384 → **49152**, matching what the verify agent already uses.

`deepseek-v4-flash` spends most of its budget on `reasoning_content` before emitting any content, so the cap is largely consumed before the answer starts. The existing docstring already recorded that 4096 returned *empty* content. 16384 got roughly 7.6K characters into a 120-file PR's claims JSON before cutting mid-string.

`max_tokens` is a ceiling, not a spend — raising it costs nothing on reviews that never approach it.

## What this deliberately does not do

It does not salvage truncated JSON by dropping the incomplete trailing element. That would turn a loud failure into a review that quietly checked 23 claims while reporting 24. For a tool whose whole point is catching what a description leaves out, silently losing a claim is worse than failing.

## Verified end to end

With this and #18, the PR #942 review that had failed three times now completes:

```
[2/5] claims — 24 claims from description
[5/5] report — 24 claims, 10 docs, 16 impact
Report: sessions/nexpeakcore/erp/pr-942/report.md
Posted round ping.
```

278 tests pass (3 new: truncation raises, complete response passes through, missing `finish_reason` is not treated as truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)