### PR TITLE
chore: bump to 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepseek-harness-pr-review"
-version = "1.2.0"
+version = "1.3.0"
 description = "Headless PR review automation on top of DeepSeek Harness"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
`1.2.0` → `1.3.0`. Six PRs merged since the last bump: two features, three fixes, one chore. No API removals, so minor.

## Features

| PR | |
|---|---|
| #14 | Adding a repo verifies it exists and is visible to your token first, so a typo cannot become a permanent config entry. `/config` and `autoreview --check-repos` flag entries GitHub can no longer reach and remove them in one click. |
| #16 | A review prints one line per phase and per agent, so the dashboard's live log is not empty for the minutes verify takes. Includes how long each agent waited for a slot — the line that later explained a 299s wait that looked like a hang. |

## Fixes

| PR | |
|---|---|
| #15 | A bare repo key means `<org>/<name>` and nothing else. The dashboard was showing AUTO for repos the poller never visits, the mode toggle wrote the wrong key (probably how the bad entries got there), and every `/config` button 404'd on keys containing a slash. |
| #18 | `gh api --paginate` emits one JSON document **per page**, so any response past 100 items was unparseable. A year-old latent crash across seven call sites; it fired when a PR grew to 120 changed files. |
| #20 | A response cut off at `max_tokens` reached the caller as a half-written document, so truncation surfaced as `Unterminated string at line 146`. Now named as truncation, with the cap raised to match the verify agent. |

## Chore

| PR | |
|---|---|
| #17 | Internal repo names scrubbed back out of tests and docstrings after this session put them into a public repo. |

## Note on the version plumbing

`src.__version__` is derived from `pyproject.toml` through the installed distribution (#13), so bumping the declaration requires reinstalling the package for the two to agree. `test_version_matches_pyproject` fails loudly if that step is skipped — which is the point; the two numbers had silently drifted (1.0.6 vs 1.1.0) before that test existed.

278 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)