### PR TITLE
fix: the header mark must be 16px without CSS

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -736,3 +736,24 @@ def test_header_omits_the_link_when_metadata_has_no_url(tmp_path, monkeypatch):
 
     monkeypatch.setattr(importlib.metadata, "metadata", missing)
     assert project_repo() is None
+
+
+def test_gh_mark_carries_its_own_size(tmp_path, monkeypatch):
+    """The mark must be 16px without CSS.
+
+    An inline <svg> with no width/height falls back to the replaced-element
+    default (300x150) the moment the stylesheet is missing or stale. A cached
+    style.css did exactly that and turned the header into a full-page banner.
+    """
+    client, _ = _cfg_client(tmp_path, monkeypatch, lambda args, **kw: [])
+    html = client.get("/").text
+    assert '<svg class="gh-mark" width="16" height="16"' in html
+
+
+def test_stylesheet_is_cache_busted(tmp_path, monkeypatch):
+    """A CSS change must not need a hard refresh to take effect."""
+    import src
+
+    client, _ = _cfg_client(tmp_path, monkeypatch, lambda args, **kw: [])
+    html = client.get("/").text
+    assert f'href="/static/style.css?v={src.__version__}"' in html

--- a/web/server.py
+++ b/web/server.py
@@ -45,6 +45,15 @@ def project_repo() -> dict | None:
 
 # Set once so base.html can use it without every route threading it through.
 templates.env.globals["project_repo"] = project_repo()
+# Stylesheet cache-buster: a CSS change otherwise needs a hard refresh, and
+# the header depends on CSS for layout it must not be broken without.
+try:
+    import importlib.metadata as _md
+
+    templates.env.globals["app_version"] = _md.version(
+        "deepseek-harness-pr-review")
+except Exception:  # noqa: BLE001 — a dev checkout must still render
+    templates.env.globals["app_version"] = "dev"
 
 app = FastAPI(title="PR Review Dashboard")
 app.mount("/static", StaticFiles(directory=str(BASE / "static")), name="static")

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>{% block title %}PR Review Dashboard{% endblock %}</title>
-  <link rel="stylesheet" href="/static/style.css">
+  <link rel="stylesheet" href="/static/style.css?v={{ app_version }}">
   {% block head %}{% endblock %}
 </head>
 <body>
@@ -14,7 +14,7 @@
     {% if project_repo %}
     <a class="crumb repo-link" target="_blank" rel="noopener"
        href="{{ project_repo.url }}" title="{{ project_repo.url }}">
-      <svg class="gh-mark" viewBox="0 0 24 24" aria-hidden="true"><path
+      <svg class="gh-mark" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true"><path
         fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
       <span>{{ project_repo.name }}</span>
     </a>


### PR DESCRIPTION
#23 rendered like this:

```
┌──────────────────────────────────────────────────────┐
│                                                      │
│                    ╭──────────╮                      │
│  PR Review          │  ~300px  │                     │
│  Dashboard  Config  │   GitHub │                     │
│                     │   logo   │                     │
│                    ╰──────────╯                      │
│        nexpeakcore/deepseek-harness-pr-review        │
└──────────────────────────────────────────────────────┘
```

## What happened

The CSS was correct (`.gh-mark { width: 16px; height: 16px }`) and the server was serving it. The browser was holding a **cached `style.css`** from before that rule existed.

That is the trigger, not the defect.

An inline `<svg>` with no `width`/`height` attributes falls back to the replaced-element default — 300×150 — whenever its stylesheet is missing, stale, or still loading. Sizing an icon purely from an external stylesheet means one cold cache turns the header into a full-page logo.

## Fix

- **Size on the element**: `<svg class="gh-mark" width="16" height="16" ...>`. Correct with zero CSS; the rule stays as reinforcement.
- **Cache-bust the stylesheet**: `/static/style.css?v={app_version}`. A CSS change needing a hard refresh is tolerable for colour — not for layout the page cannot survive without. This is the second staleness bug in a week, after a dashboard served 22-hour-old code because nothing signalled the running version.

## How it got through

I merged #23 having verified only the HTML with `curl`. `curl` does not render, so nothing I looked at could have shown this. Checking markup is not checking a page.

283 tests pass (2 new: the mark carries its own size, the stylesheet is versioned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)