### PR TITLE
feat: run reviews on the Claude Code CLI as a second agent backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# Agent backend: deepseek (default) or claude.
+# deepseek → DeepSeek Harness SDK, needs DEEPSEEK_API_KEY below.
+# claude   → headless `claude -p` (Claude Code CLI), brings its own credentials.
+HARNESS_PROVIDER=deepseek
+HARNESS_CLAUDE_MODEL=sonnet
+
 DEEPSEEK_API_KEY=sk-your-key-here
 DSH_MODEL=deepseek-v4-flash
 DEEPSEEK_BASE_URL=https://api.deepseek.com/v1

--- a/README.md
+++ b/README.md
@@ -92,10 +92,55 @@ export DEEPSEEK_API_KEY=sk-...   # see .env.example
 harness-pr-review doctor         # verify everything is ready
 ```
 
+Running the review on Claude instead? Then no DeepSeek key is needed — see
+[Agent backends](#agent-backends).
+
 Keys can also live in a `.env` file. Two locations are read, in order:
 `./.env` (dev checkout) then `~/.harness-pr-review/.env` (one-liner install,
 so the CLI works from any directory). The first file to define a key wins, and
 a real environment variable always beats both.
+
+## Agent backends
+
+The review logic does not care which agent runtime reads the workspace, so the
+backend is one env var. Everything else — phases, prompts, schemas, report,
+comments — is identical either way.
+
+| `HARNESS_PROVIDER` | Runtime | Credentials |
+|---|---|---|
+| `deepseek` (default) | DeepSeek Harness SDK, composed by `cordis/minimal.cordis.yml` | `DEEPSEEK_API_KEY` |
+| `claude` | Headless `claude -p` (Claude Code CLI) | whatever the CLI is already logged in with — a Claude subscription is enough, no extra API key |
+
+```bash
+export HARNESS_PROVIDER=claude
+export HARNESS_CLAUDE_MODEL=sonnet   # or opus / haiku / a full model id
+harness-pr-review doctor             # now checks for the claude binary, not the SDK
+harness-pr-review owner/repo 123
+```
+
+The phase log names the backend that actually ran, so a review that quietly
+used the wrong one is visible in the dashboard:
+
+```
+[4/5] verify — starting agents
+      4 agents on claude/sonnet: claims-1, claims-2, docs, impact (cap 4 concurrent)
+```
+
+**The workspace is an untrusted PR**, and the Claude backend is locked down to
+match the sandbox policy the SDK backend runs under:
+
+- Tools are limited to `Read`, `Grep`, `Glob`, `Write` — no shell, no editing
+  files outside the part it is asked to write, no network.
+- `--safe-mode`, `--setting-sources user` and `--strict-mcp-config` mean a
+  `CLAUDE.md`, `.claude/settings.json`, hook or `.mcp.json` **committed inside
+  the reviewed repo is not loaded** — a PR does not get to configure the agent
+  reviewing it.
+- Each agent runs under `--max-budget-usd`, so a loop that stops making
+  progress stops spending.
+
+Per-agent cost, session id and any permission denial land in
+`sessions/<owner>/<repo>/pr-<n>/claude-<axis>.json`, next to the existing
+artefacts.
 
 ## Updating
 
@@ -153,9 +198,10 @@ Results land in `sessions/<owner>/<repo>/pr-<n>/report.md` (change the directory
 
 1. **Snapshot** — fetch PR metadata, diff files, commits, review threads (GitHub REST + GraphQL)
 2. **Claims** — LLM splits the description into verifiable claims
-3. **Verify** — DeepSeek Harness agent deep-dives in a disposable worktree:
+3. **Verify** — the agent backend deep-dives in a disposable worktree:
    verifies each claim, docs reality-check (MATCH/STALE/WRONG/FABRICATED),
-   requirement impact, review thread status
+   requirement impact, review thread status. DeepSeek Harness by default,
+   Claude Code with `HARNESS_PROVIDER=claude` — see [Agent backends](#agent-backends)
 4. **Human gate** — asks for confirmation (≤20 words/question) when docs are wrong or claims are uncertain
 5. **Synthesize** — English report.md + two comments on the PR:
    - **The report** — one comment, edited in place on every re-review so the PR
@@ -277,8 +323,10 @@ re-run with `--force`; the PR comment is updated in place (never duplicated).
 
 | Env | Default | Meaning |
 |---|---|---|
-| `DEEPSEEK_API_KEY` | — | DeepSeek API key |
-| `DSH_MODEL` | `deepseek-v4-flash` | Model used for the agent + claim extraction |
+| `HARNESS_PROVIDER` | `deepseek` | Agent backend: `deepseek` or `claude` (see [Agent backends](#agent-backends)) |
+| `HARNESS_CLAUDE_MODEL` | `sonnet` | Model for the `claude` backend |
+| `DEEPSEEK_API_KEY` | — | DeepSeek API key (only required by the `deepseek` backend) |
+| `DSH_MODEL` | `deepseek-v4-flash` | Model for the `deepseek` backend (agent + claim extraction) |
 | `DEEPSEEK_BASE_URL` | `https://api.deepseek.com/v1` | OpenAI-compatible endpoint |
 | `DSH_SESSION_ROOT` | `sessions` | Directory storing per-phase results |
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,14 @@ used the wrong one is visible in the dashboard:
 **The workspace is an untrusted PR**, and the Claude backend is locked down to
 match the sandbox policy the SDK backend runs under:
 
-- Tools are limited to `Read`, `Grep`, `Glob`, `Write` — no shell, no editing
-  files outside the part it is asked to write, no network.
+- `--tools Read,Grep,Glob,Write` — no shell, no editing, no network. This is
+  the flag that decides which built-in tools *exist* for the run.
+  `--allowedTools` alone is not a boundary: it only pre-approves what may run
+  without a prompt, so a tool left out of it is still present and a user
+  settings rule can approve it. Both are passed, from the same list.
+- Phase 2 (claim extraction) runs with `--tools ""` — **no tools at all**. It
+  is text in, JSON out, its prompt carries the untrusted PR description and
+  diff, and unlike phase 3 it has no sandboxed workspace confining it.
 - `--safe-mode`, `--setting-sources user` and `--strict-mcp-config` mean a
   `CLAUDE.md`, `.claude/settings.json`, hook or `.mcp.json` **committed inside
   the reviewed repo is not loaded** — a PR does not get to configure the agent

--- a/scripts/autoreview-once.sh
+++ b/scripts/autoreview-once.sh
@@ -2,6 +2,11 @@
 # One-shot auto review pass, launched by launchd every 2 minutes.
 # Loads .env (DEEPSEEK_API_KEY etc.) if present, so the key never sits in the plist.
 cd "$(dirname "$0")/.."
+# launchd hands this job a minimal PATH (see the plist), which does not include
+# the per-user bin dir that npm, pipx and the Claude Code installer all write
+# to. Without this the claude backend fails at phase 2 with "not found on PATH"
+# while the very same review works from an interactive shell.
+export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
 if [ -f .env ]; then
   set -a
   source .env

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -104,3 +104,4 @@ say "Checking readiness..."
 
 say "Done. Run 'harness-pr-review doctor' (or open a new terminal) to verify."
 say "Next: gh auth login  &&  export DEEPSEEK_API_KEY=sk-..."
+say "      (or export HARNESS_PROVIDER=claude to run the review on the Claude Code CLI — no API key needed)"

--- a/src/autoreview.py
+++ b/src/autoreview.py
@@ -361,6 +361,20 @@ def main(argv: list[str] | None = None) -> int:
     if env.needs_deepseek_key and not env.api_key:
         print("DEEPSEEK_API_KEY not set (see .env.example)", file=sys.stderr)
         return 3
+    if env.provider == "claude":
+        # Checked here and not left to the children: a review that dies in
+        # claim extraction leaves a snapshot and no findings, so decide_pr
+        # queues the same PR again on the next interval — every interval,
+        # forever. That is not hypothetical; a launchd PATH without the
+        # per-user bin dir did exactly this.
+        from src import claude_cli
+
+        if not claude_cli.available():
+            print(f"HARNESS_PROVIDER=claude but the claude CLI is not on PATH "
+                  f"— install Claude Code (https://claude.com/claude-code). "
+                  f"PATH was: {os.environ.get('PATH', '(unset)')}",
+                  file=sys.stderr)
+            return 2
     if not gh_available():
         print("gh CLI not installed or not authenticated (gh auth login)",
               file=sys.stderr)

--- a/src/autoreview.py
+++ b/src/autoreview.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from src.autoreview_config import auto_repos, list_repos, load_config, \
     remove_repo, set_repo_mode
+from src.config import PROVIDERS
 from src.config import load_config as load_env_config
 from src.gh import gh_available, run_gh
 from src.review_proc import review_lock_alive
@@ -353,6 +354,10 @@ def main(argv: list[str] | None = None) -> int:
 
     cfg = load_config(args.config)
     env = load_env_config()
+    if env.provider not in PROVIDERS:
+        print(f"unknown HARNESS_PROVIDER={env.provider!r} — expected one of: "
+              f"{', '.join(PROVIDERS)}", file=sys.stderr)
+        return 2
     if env.needs_deepseek_key and not env.api_key:
         print("DEEPSEEK_API_KEY not set (see .env.example)", file=sys.stderr)
         return 3

--- a/src/autoreview.py
+++ b/src/autoreview.py
@@ -353,7 +353,7 @@ def main(argv: list[str] | None = None) -> int:
 
     cfg = load_config(args.config)
     env = load_env_config()
-    if not env.api_key:
+    if env.needs_deepseek_key and not env.api_key:
         print("DEEPSEEK_API_KEY not set (see .env.example)", file=sys.stderr)
         return 3
     if not gh_available():

--- a/src/claims.py
+++ b/src/claims.py
@@ -176,22 +176,39 @@ def _parse_claims(raw: str, source: str) -> list[dict]:
 
 def _run_pass(system: str, user: str, cfg: dict, source: str, chat) -> list[dict]:
     try:
+        # api_key/base_url are the OpenAI-compatible backend's business; the
+        # Claude one ignores them, so they are read as optional here rather
+        # than demanded of every provider's config.
         raw = chat([{"role": "system", "content": system},
                     {"role": "user", "content": user}],
-                   model=cfg["model"], api_key=cfg["api_key"],
-                   base_url=cfg["base_url"])
+                   model=cfg["model"], api_key=cfg.get("api_key", ""),
+                   base_url=cfg.get("base_url", ""))
         return _parse_claims(raw, source)
     except (json.JSONDecodeError, ValueError, RuntimeError) as e:
         raise RuntimeError(f"invalid claims response ({source}): {e}") from e
 
 
+def select_chat(provider: str | None):
+    """The chat implementation for a provider.
+
+    Phase 2 has no workspace to read — it is a single text-in/JSON-out call —
+    so the Claude backend enters here as a chat function with the same
+    signature rather than as an agent runner.
+    """
+    if (provider or "").strip().lower() == "claude":
+        from src import claude_cli
+        return claude_cli.chat
+    return _default_chat
+
+
 def extract_claims(snapshot: dict, cfg: dict, session_dir: Path,
-                   chat=_default_chat) -> list[dict]:
+                   chat=None) -> list[dict]:
     """Extract claims from the snapshot. Save claims.json, return the claims list.
 
     Falls back to inferred claims when the description is thin, or when the
     stated pass finds nothing verifiable in it.
     """
+    chat = chat or select_chat(cfg.get("provider"))
     claims: list[dict] = []
     if not description_is_thin(snapshot):
         description = f"# Title: {snapshot['title']}\n\n{snapshot['body']}"

--- a/src/claude_cli.py
+++ b/src/claude_cli.py
@@ -1,0 +1,224 @@
+"""Claude Code CLI as a second agent backend (headless `claude -p`).
+
+The pipeline was written against one agent runtime — the DeepSeek Harness SDK —
+but no phase actually depends on *which* agent reads the workspace. verify.py
+already takes an injectable `runner` and claims.py an injectable `chat`, so a
+second backend is a matter of filling those two seams rather than threading a
+provider flag through every phase.
+
+Why the CLI and not the Anthropic API directly: phase 3 needs a tool loop (read
+the repo, then write findings-<axis>.json), and `claude -p` *is* that loop. It
+also carries its own credentials, so a Claude subscription login is enough —
+this backend adds no second API key to .env.
+
+The workspace holds a PR from a repo we do not control, so every invocation is
+narrowed the same way cordis/minimal.cordis.yml narrows the DeepSeek agent:
+
+- `--allowedTools` — read the code, write one part file. No Bash, no Edit, no
+  network. In print mode anything else is auto-denied instead of prompting, so
+  a blocked tool costs a turn rather than hanging the review.
+- `--safe-mode` — the checked-out repo's own CLAUDE.md, hooks, skills, plugins
+  and custom agents are not loaded. Without it a PR could ship a CLAUDE.md and
+  steer the reviewer that is meant to be reviewing it.
+- `--setting-sources user` + `--strict-mcp-config` — same reasoning for a
+  .claude/settings.json or .mcp.json committed inside the workspace.
+- cwd is the workspace, so the Write tool lands the part file exactly where
+  verify.read_part() looks for it.
+"""
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+BINARY = "claude"
+DEFAULT_MODEL = "sonnet"
+
+# Read the code, write one findings part. Nothing else.
+AGENT_TOOLS = ("Read", "Grep", "Glob", "Write")
+
+# A verify agent greps a whole repo; 30 minutes matches the streamIdleTimeoutMs
+# the SDK backend runs with.
+DEFAULT_TIMEOUT_SECONDS = 1800
+
+# Per-agent ceiling, not a target: a review costs cents, so anything near this
+# is a loop that stopped making progress. Guards the account, not the budget.
+DEFAULT_MAX_BUDGET_USD = 5.0
+
+# claims.py sends a self-contained prompt — everything the model needs is in
+# the text. Saying so up front avoids a wasted turn spent reaching for Read in
+# a directory that holds nothing to read.
+NO_TOOLS_HINT = ("Answer directly from the information given above. "
+                 "Do not use tools.")
+
+
+def available() -> bool:
+    """True if the claude binary is on PATH."""
+    return shutil.which(BINARY) is not None
+
+
+def version() -> str:
+    """`claude --version` output, or "" if it cannot be run."""
+    try:
+        proc = subprocess.run([BINARY, "--version"], capture_output=True,
+                              text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def build_argv(*, model: str, allowed_tools: tuple = (),
+               system: str | None = None,
+               max_budget_usd: float | None = DEFAULT_MAX_BUDGET_USD) -> list[str]:
+    """The full command line for one headless turn.
+
+    Tools go in as one comma-separated argument rather than as the variadic
+    space-separated form: variadic options swallow whatever follows them, and
+    the list here is built next to other flags.
+    """
+    argv = [BINARY, "-p",
+            "--output-format", "json",
+            "--model", model,
+            # Nothing inside the reviewed repo gets to configure its reviewer.
+            "--safe-mode",
+            "--strict-mcp-config",
+            "--setting-sources", "user"]
+    if allowed_tools:
+        argv += ["--allowedTools", ",".join(allowed_tools)]
+    if system:
+        argv += ["--append-system-prompt", system]
+    if max_budget_usd:
+        argv += ["--max-budget-usd", str(max_budget_usd)]
+    return argv
+
+
+def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
+        allowed_tools: tuple = (), system: str | None = None,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        max_budget_usd: float | None = DEFAULT_MAX_BUDGET_USD,
+        meta_path: Path | None = None,
+        _run=subprocess.run) -> str:
+    """Run one headless turn and return the agent's final text.
+
+    The prompt goes over stdin, never argv: a claims prompt carries the PR
+    body, the diff digest and every claim as JSON, and on a large PR that
+    overruns ARG_MAX long before it overruns the context window.
+
+    `meta_path` receives the run envelope (cost, session id, permission
+    denials) minus the reply itself — written before the result is judged, so
+    a failed agent still leaves something to read in sessions/.
+    """
+    argv = build_argv(model=model, allowed_tools=allowed_tools, system=system,
+                      max_budget_usd=max_budget_usd)
+    try:
+        proc = _run(argv, input=prompt, cwd=None if cwd is None else str(cwd),
+                    capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            f"{BINARY} CLI not found on PATH — install Claude Code "
+            f"(https://claude.com/claude-code), or set HARNESS_PROVIDER=deepseek"
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"{BINARY} timed out after {timeout}s") from e
+    except OSError as e:
+        raise RuntimeError(f"could not run {BINARY}: {e}") from e
+
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if not stdout:
+        raise RuntimeError(
+            f"{BINARY} exited {proc.returncode} with no output"
+            + (f": {stderr[:300]}" if stderr else ""))
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"{BINARY} returned non-JSON output ({e}): {stdout[:300]}") from e
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{BINARY} returned an unexpected payload shape")
+
+    if meta_path is not None:
+        _write_meta(meta_path, data)
+
+    result = data.get("result")
+    if data.get("is_error") or data.get("subtype") != "success":
+        detail = result if isinstance(result, str) and result else stderr
+        raise RuntimeError(
+            f"{BINARY} failed ({data.get('subtype') or 'error'}): "
+            f"{(detail or 'no detail')[:300]}")
+    if not isinstance(result, str) or not result.strip():
+        raise RuntimeError(f"{BINARY} returned an empty result")
+    return result
+
+
+def _write_meta(path: Path, data: dict) -> None:
+    """Save the run envelope next to the other session artefacts. Never fatal."""
+    meta = {k: v for k, v in data.items() if k != "result"}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(meta, indent=2))
+    except (OSError, TypeError, ValueError):
+        pass
+
+
+_FENCE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+
+def extract_json_object(text: str) -> str | None:
+    """The first complete JSON object in `text`, or None if there is none.
+
+    The agent is told to WRITE its part file and normally does. When it answers
+    with the JSON inline instead, the part file is missing and read_part()
+    fails that whole axis — a docs check lost to a formatting slip. Recovering
+    the object from the reply is cheaper and more honest than re-running it.
+    """
+    if not text:
+        return None
+    fence = _FENCE.search(text)
+    candidate = fence.group(1).strip() if fence else text
+    start = candidate.find("{")
+    if start < 0:
+        return None
+    depth, in_string, escaped = 0, False, False
+    for i in range(start, len(candidate)):
+        ch = candidate[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                blob = candidate[start:i + 1]
+                try:
+                    json.loads(blob)
+                except json.JSONDecodeError:
+                    return None
+                return blob
+    return None
+
+
+def chat(messages: list[dict], *, model: str, api_key: str = "",
+         base_url: str = "", max_tokens: int | None = None,
+         retries: int = 3, **_) -> str:
+    """`src.llm.chat`-shaped adapter, so claims.py can take this backend as-is.
+
+    api_key, base_url, max_tokens and retries are accepted and ignored: the CLI
+    carries its own credentials, its own output cap, and its own retry on
+    overload. Keeping the signature identical is the whole point — it is what
+    lets extract_claims() take either backend through the same `chat` argument.
+    """
+    system = "\n\n".join(m["content"] for m in messages
+                         if m.get("role") == "system")
+    user = "\n\n".join(m["content"] for m in messages
+                       if m.get("role") != "system")
+    return run(user, model=model,
+               system=f"{system}\n\n{NO_TOOLS_HINT}".strip())

--- a/src/claude_cli.py
+++ b/src/claude_cli.py
@@ -34,6 +34,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 BINARY = "claude"
@@ -59,6 +60,15 @@ DEFAULT_MAX_BUDGET_USD = 5.0
 # a directory that holds nothing to read.
 NO_TOOLS_HINT = ("Answer directly from the information given above. "
                  "Do not use tools.")
+
+# A run that died inside the API rather than on its own terms. Seen for real:
+# four agents launched together all came back at 11s with "Not logged in ·
+# Please run /login" — terminal_reason api_error, one turn, zero cost — while
+# the CLI was logged in the whole time and a ping right after succeeded. A
+# blip like that took down the entire review, because unlike the DeepSeek
+# backend nothing here tried twice.
+RETRY_TERMINAL_REASONS = ("api_error",)
+DEFAULT_RETRIES = 3
 
 
 def available() -> bool:
@@ -115,8 +125,8 @@ def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
         tools: tuple = NO_TOOLS, system: str | None = None,
         timeout: int = DEFAULT_TIMEOUT_SECONDS,
         max_budget_usd: float | None = DEFAULT_MAX_BUDGET_USD,
-        meta_path: Path | None = None,
-        _run=subprocess.run) -> str:
+        meta_path: Path | None = None, retries: int = DEFAULT_RETRIES,
+        _run=subprocess.run, _sleep=time.sleep) -> str:
     """Run one headless turn and return the agent's final text.
 
     The prompt goes over stdin, never argv: a claims prompt carries the PR
@@ -126,9 +136,31 @@ def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
     `meta_path` receives the run envelope (cost, session id, permission
     denials) minus the reply itself — written before the result is judged, so
     a failed agent still leaves something to read in sessions/.
+
+    A run that failed inside the API is retried with the same backoff the
+    DeepSeek backend uses. Everything else — a bad model id, a missing binary,
+    an unparseable reply — fails on the first attempt, because trying it again
+    only spends the review's time to reach the same answer.
     """
     argv = build_argv(model=model, tools=tools, system=system,
                       max_budget_usd=max_budget_usd)
+    for attempt in range(1, max(1, retries) + 1):
+        try:
+            return _attempt(argv, prompt, cwd=cwd, timeout=timeout,
+                            meta_path=meta_path, _run=_run)
+        except _Transient as e:
+            if attempt == max(1, retries):
+                raise RuntimeError(f"{e} (after {attempt} attempts)") from e
+            _sleep(2 * attempt)
+    raise AssertionError("unreachable")
+
+
+class _Transient(RuntimeError):
+    """A failure worth trying again — raised only by _attempt."""
+
+
+def _attempt(argv: list[str], prompt: str, *, cwd, timeout, meta_path,
+             _run) -> str:
     try:
         proc = _run(argv, input=prompt, cwd=None if cwd is None else str(cwd),
                     capture_output=True, text=True, timeout=timeout)
@@ -166,9 +198,15 @@ def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
     result = data.get("result")
     if data.get("is_error") or data.get("subtype") != "success":
         detail = result if isinstance(result, str) and result else stderr
-        raise RuntimeError(
-            f"{BINARY} failed ({data.get('subtype') or 'error'}): "
-            f"{(detail or 'no detail')[:300]}")
+        # subtype stays "success" for a run that died in the API, so the
+        # reason the run ended is what has to be reported and classified —
+        # not the subtype, which would read as a contradiction in the log.
+        reason = data.get("terminal_reason") or data.get("subtype") or "error"
+        message = (f"{BINARY} failed ({reason}): "
+                   f"{(detail or 'no detail')[:300]}")
+        if reason in RETRY_TERMINAL_REASONS or data.get("api_error_status"):
+            raise _Transient(message)
+        raise RuntimeError(message)
     if not isinstance(result, str) or not result.strip():
         raise RuntimeError(f"{BINARY} returned an empty result")
     return result

--- a/src/claude_cli.py
+++ b/src/claude_cli.py
@@ -14,9 +14,13 @@ this backend adds no second API key to .env.
 The workspace holds a PR from a repo we do not control, so every invocation is
 narrowed the same way cordis/minimal.cordis.yml narrows the DeepSeek agent:
 
-- `--allowedTools` — read the code, write one part file. No Bash, no Edit, no
-  network. In print mode anything else is auto-denied instead of prompting, so
-  a blocked tool costs a turn rather than hanging the review.
+- `--tools` — the boundary. It sets which built-in tools *exist* for the run:
+  read the code, write one part file, nothing else. `--allowedTools` is not a
+  boundary and was the first thing tried here — it only pre-approves what may
+  run without a prompt, so a tool left out of it still exists, and a user
+  settings rule can approve it anyway. `--tools ""` removes every tool, which
+  is what phase 2 runs with. Both are passed: --tools decides what exists,
+  --allowedTools keeps what exists from stopping to ask.
 - `--safe-mode` — the checked-out repo's own CLAUDE.md, hooks, skills, plugins
   and custom agents are not loaded. Without it a PR could ship a CLAUDE.md and
   steer the reviewer that is meant to be reviewing it.
@@ -35,8 +39,12 @@ from pathlib import Path
 BINARY = "claude"
 DEFAULT_MODEL = "sonnet"
 
-# Read the code, write one findings part. Nothing else.
+# Read the code, write one findings part. Nothing else exists for the run.
 AGENT_TOOLS = ("Read", "Grep", "Glob", "Write")
+# Phase 2 is text in, JSON out, with no workspace to read — and its prompt
+# carries the PR description and diff, which are untrusted. Nothing to gain
+# from a tool, everything to lose.
+NO_TOOLS = ()
 
 # A verify agent greps a whole repo; 30 minutes matches the streamIdleTimeoutMs
 # the SDK backend runs with.
@@ -68,10 +76,13 @@ def version() -> str:
     return proc.stdout.strip() if proc.returncode == 0 else ""
 
 
-def build_argv(*, model: str, allowed_tools: tuple = (),
+def build_argv(*, model: str, tools: tuple = NO_TOOLS,
                system: str | None = None,
                max_budget_usd: float | None = DEFAULT_MAX_BUDGET_USD) -> list[str]:
     """The full command line for one headless turn.
+
+    `tools` defaults to none at all, so a new call site has to ask for reach
+    rather than inherit it.
 
     Tools go in as one comma-separated argument rather than as the variadic
     space-separated form: variadic options swallow whatever follows them, and
@@ -84,8 +95,15 @@ def build_argv(*, model: str, allowed_tools: tuple = (),
             "--safe-mode",
             "--strict-mcp-config",
             "--setting-sources", "user"]
-    if allowed_tools:
-        argv += ["--allowedTools", ",".join(allowed_tools)]
+    # --tools is the real boundary: it decides which built-in tools exist at
+    # all, and "" removes every one of them. --allowedTools only says which of
+    # the surviving tools may run without stopping to ask, so on its own it
+    # would leave Bash present and merely unapproved — and a user settings rule
+    # could approve it. Both are set from the same list so the two can never
+    # disagree about what this run may touch.
+    argv += ["--tools", ",".join(tools)]
+    if tools:
+        argv += ["--allowedTools", ",".join(tools)]
     if system:
         argv += ["--append-system-prompt", system]
     if max_budget_usd:
@@ -94,7 +112,7 @@ def build_argv(*, model: str, allowed_tools: tuple = (),
 
 
 def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
-        allowed_tools: tuple = (), system: str | None = None,
+        tools: tuple = NO_TOOLS, system: str | None = None,
         timeout: int = DEFAULT_TIMEOUT_SECONDS,
         max_budget_usd: float | None = DEFAULT_MAX_BUDGET_USD,
         meta_path: Path | None = None,
@@ -109,7 +127,7 @@ def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
     denials) minus the reply itself — written before the result is judged, so
     a failed agent still leaves something to read in sessions/.
     """
-    argv = build_argv(model=model, allowed_tools=allowed_tools, system=system,
+    argv = build_argv(model=model, tools=tools, system=system,
                       max_budget_usd=max_budget_usd)
     try:
         proc = _run(argv, input=prompt, cwd=None if cwd is None else str(cwd),
@@ -220,6 +238,10 @@ def chat(messages: list[dict], *, model: str, api_key: str = "",
     carries its own credentials, its own output cap, and its own retry on
     overload. Keeping the signature identical is the whole point — it is what
     lets extract_claims() take either backend through the same `chat` argument.
+
+    Runs with no tools at all. The prompt carries the PR description and diff,
+    which are untrusted, and unlike phase 3 this call has no sandboxed
+    workspace confining it — its cwd is wherever the review was started.
     """
     system = "\n\n".join(m["content"] for m in messages
                          if m.get("role") == "system")

--- a/src/claude_cli.py
+++ b/src/claude_cli.py
@@ -26,6 +26,7 @@ narrowed the same way cordis/minimal.cordis.yml narrows the DeepSeek agent:
   verify.read_part() looks for it.
 """
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -114,10 +115,14 @@ def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
         proc = _run(argv, input=prompt, cwd=None if cwd is None else str(cwd),
                     capture_output=True, text=True, timeout=timeout)
     except FileNotFoundError as e:
+        # The PATH is part of the error because the usual cause is not a
+        # missing install: it is a launcher (launchd, cron, systemd) handing
+        # the process a PATH that omits the per-user bin dir, so the same
+        # review works by hand and fails on a schedule.
         raise RuntimeError(
             f"{BINARY} CLI not found on PATH — install Claude Code "
-            f"(https://claude.com/claude-code), or set HARNESS_PROVIDER=deepseek"
-        ) from e
+            f"(https://claude.com/claude-code), or set HARNESS_PROVIDER=deepseek. "
+            f"PATH was: {os.environ.get('PATH', '(unset)')}") from e
     except subprocess.TimeoutExpired as e:
         raise RuntimeError(f"{BINARY} timed out after {timeout}s") from e
     except OSError as e:

--- a/src/claude_cli.py
+++ b/src/claude_cli.py
@@ -126,7 +126,8 @@ def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
         timeout: int = DEFAULT_TIMEOUT_SECONDS,
         max_budget_usd: float | None = DEFAULT_MAX_BUDGET_USD,
         meta_path: Path | None = None, retries: int = DEFAULT_RETRIES,
-        _run=subprocess.run, _sleep=time.sleep) -> str:
+        reset_paths: tuple = (), _run=subprocess.run,
+        _sleep=time.sleep) -> str:
     """Run one headless turn and return the agent's final text.
 
     The prompt goes over stdin, never argv: a claims prompt carries the PR
@@ -141,10 +142,20 @@ def run(prompt: str, *, model: str = DEFAULT_MODEL, cwd: Path | None = None,
     DeepSeek backend uses. Everything else — a bad model id, a missing binary,
     an unparseable reply — fails on the first attempt, because trying it again
     only spends the review's time to reach the same answer.
+
+    `reset_paths` are removed before every attempt. An attempt can write its
+    output file and *then* die in the API; if the retry answers inline instead
+    of writing, the caller's salvage sees a file already there, skips, and the
+    dead attempt's half-written JSON is read as the result.
     """
     argv = build_argv(model=model, tools=tools, system=system,
                       max_budget_usd=max_budget_usd)
     for attempt in range(1, max(1, retries) + 1):
+        for stale in reset_paths:
+            try:
+                Path(stale).unlink(missing_ok=True)
+            except OSError:
+                pass
         try:
             return _attempt(argv, prompt, cwd=cwd, timeout=timeout,
                             meta_path=meta_path, _run=_run)

--- a/src/config.py
+++ b/src/config.py
@@ -50,10 +50,12 @@ class Config:
     def needs_deepseek_key(self) -> bool:
         """Only the DeepSeek backend is blocked by a missing DEEPSEEK_API_KEY.
 
-        Asked as a property rather than compared inline, because three call
-        sites gate on it (run, autoreview, doctor) and each one drifting into
-        its own `== "deepseek"` check is how the Claude path ends up demanding
-        a key it never uses.
+        Asked as a property rather than compared inline, because three
+        entry points gate on it — the CLI, the autoreview poller and the
+        dashboard's Review now — and each drifting into its own
+        `== "deepseek"` check is how one of them ends up demanding a key it
+        never uses. The dashboard did exactly that and 400'd every review
+        under the Claude backend while the CLI ran the same review fine.
         """
         return self.provider == "deepseek"
 

--- a/src/config.py
+++ b/src/config.py
@@ -30,12 +30,48 @@ def _load_dotenv() -> None:
 _load_dotenv()
 
 
+# Agent backends. "deepseek" runs the Harness SDK against the DeepSeek API and
+# needs DEEPSEEK_API_KEY; "claude" shells out to the Claude Code CLI, which
+# brings its own credentials (see src/claude_cli.py).
+PROVIDERS = ("deepseek", "claude")
+DEFAULT_PROVIDER = "deepseek"
+
+
 @dataclass(frozen=True)
 class Config:
     api_key: str
     model: str
     base_url: str
     session_root: Path
+    provider: str = DEFAULT_PROVIDER
+    claude_model: str = "sonnet"
+
+    @property
+    def needs_deepseek_key(self) -> bool:
+        """Only the DeepSeek backend is blocked by a missing DEEPSEEK_API_KEY.
+
+        Asked as a property rather than compared inline, because three call
+        sites gate on it (run, autoreview, doctor) and each one drifting into
+        its own `== "deepseek"` check is how the Claude path ends up demanding
+        a key it never uses.
+        """
+        return self.provider == "deepseek"
+
+    def phase_cfg(self) -> dict:
+        """Model config for phases 2 and 3, with `model` already resolved.
+
+        Both phases take a plain dict, and both need the same answer to "which
+        model is actually going to run". Resolving it once here keeps the
+        provider fork out of the phase code, which cares about the model, not
+        about where it came from.
+        """
+        return {
+            "provider": self.provider,
+            "model": self.claude_model if self.provider == "claude" else self.model,
+            "claude_model": self.claude_model,
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+        }
 
 
 def load_config() -> Config:
@@ -44,4 +80,7 @@ def load_config() -> Config:
         model=os.environ.get("DSH_MODEL", "deepseek-v4-flash"),
         base_url=os.environ.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"),
         session_root=Path(os.environ.get("DSH_SESSION_ROOT", "sessions")),
+        provider=os.environ.get("HARNESS_PROVIDER", DEFAULT_PROVIDER).strip().lower()
+                 or DEFAULT_PROVIDER,
+        claude_model=os.environ.get("HARNESS_CLAUDE_MODEL", "sonnet").strip() or "sonnet",
     )

--- a/src/run.py
+++ b/src/run.py
@@ -9,7 +9,7 @@ import json
 import sys
 from pathlib import Path
 
-from src.config import load_config
+from src.config import PROVIDERS, load_config
 from src.gh import gh_available, run_gh
 from src.claims import all_inferred
 from src.review_proc import review_lock_alive
@@ -20,7 +20,7 @@ from src.verify import run_verify, setup_workspace
 
 
 def _doctor() -> int:
-    """Check readiness: Python, gh, API key, SDK, config. Exit 0 if ready."""
+    """Check readiness: Python, gh, the selected backend, config. Exit 0 if ready."""
     import platform
 
     ok = True
@@ -43,19 +43,37 @@ def _doctor() -> int:
         ok = False
 
     cfg = load_config()
-    if cfg.api_key:
-        print("✓ DEEPSEEK_API_KEY set")
-    else:
-        print("✗ DEEPSEEK_API_KEY not set — see .env.example")
+    if cfg.provider not in PROVIDERS:
+        print(f"✗ HARNESS_PROVIDER={cfg.provider!r} unknown — expected one of: "
+              f"{', '.join(PROVIDERS)}")
         ok = False
+    elif cfg.provider == "claude":
+        print(f"✓ provider: claude (model {cfg.claude_model})")
+        from src import claude_cli
 
-    try:
-        importlib.metadata.version("deepseek-harness-sdk")
-        print(f"✓ deepseek-harness-sdk installed "
-              f"({importlib.metadata.version('deepseek-harness-sdk')})")
-    except importlib.metadata.PackageNotFoundError:
-        print("✗ deepseek-harness-sdk not installed — run `pip install -e '.[dev]'`")
-        ok = False
+        installed = claude_cli.version() if claude_cli.available() else ""
+        if installed:
+            print(f"✓ claude CLI installed ({installed})")
+            print("· the CLI carries its own credentials — no API key needed here")
+        else:
+            print("✗ claude CLI not found on PATH — install Claude Code: "
+                  "https://claude.com/claude-code")
+            ok = False
+    else:
+        print(f"✓ provider: deepseek (model {cfg.model})")
+        if cfg.api_key:
+            print("✓ DEEPSEEK_API_KEY set")
+        else:
+            print("✗ DEEPSEEK_API_KEY not set — see .env.example")
+            ok = False
+
+        try:
+            importlib.metadata.version("deepseek-harness-sdk")
+            print(f"✓ deepseek-harness-sdk installed "
+                  f"({importlib.metadata.version('deepseek-harness-sdk')})")
+        except importlib.metadata.PackageNotFoundError:
+            print("✗ deepseek-harness-sdk not installed — run `pip install -e '.[dev]'`")
+            ok = False
 
     from src.autoreview_config import load_config as load_autoreview_config
 
@@ -273,7 +291,8 @@ def main(argv: list[str] | None = None) -> int:
                              "(for e2e, skips gh & model)")
     parser.add_argument("--version", action="store_true",
                         help="print the installed version")
-    parser.add_argument("doctor", nargs="?", help="check readiness (Python, gh, API key, SDK)")
+    parser.add_argument("doctor", nargs="?",
+                        help="check readiness (Python, gh, agent backend)")
     parser.add_argument("update", nargs="?", help="self-update from GitHub")
     parser.add_argument("web", nargs="?", help="open the web dashboard at http://127.0.0.1:6789")
     args = parser.parse_args(argv)
@@ -311,7 +330,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     cfg = load_config()
-    if not cfg.api_key and args.fixtures is None:
+    if cfg.provider not in PROVIDERS:
+        print(f"unknown HARNESS_PROVIDER={cfg.provider!r} — expected one of: "
+              f"{', '.join(PROVIDERS)}", file=sys.stderr)
+        return 2
+    if cfg.needs_deepseek_key and not cfg.api_key and args.fixtures is None:
         print("DEEPSEEK_API_KEY not set (see .env.example)", file=sys.stderr)
         return 3
     if not gh_available() and args.fixtures is None:
@@ -355,9 +378,7 @@ def main(argv: list[str] | None = None) -> int:
             claims = _load_or_skip("claims.json", session_dir, args.force)
             if claims is None:
                 _phase(2, "claims", "reading the PR description")
-                claims = extract_claims(
-                    snapshot, {"model": cfg.model, "api_key": cfg.api_key,
-                               "base_url": cfg.base_url}, session_dir)
+                claims = extract_claims(snapshot, cfg.phase_cfg(), session_dir)
             source = "inferred from code" if all_inferred(claims) else "from description"
             _phase(2, "claims", f"{len(claims)} claims {source}")
 
@@ -367,8 +388,8 @@ def main(argv: list[str] | None = None) -> int:
                 _phase(3, "workspace", "cloning + checking out the PR head")
                 setup_workspace(owner, repo, int(num), workspace)
                 _phase(4, "verify", "starting agents")
-                findings = run_verify(
-                    {"model": cfg.model}, workspace, session_dir, snapshot, claims)
+                findings = run_verify(cfg.phase_cfg(), workspace, session_dir,
+                                      snapshot, claims)
                 (session_dir / "findings.json").write_text(
                     json.dumps(findings, indent=2))
                 _bump_rounds(session_dir)

--- a/src/verify.py
+++ b/src/verify.py
@@ -290,7 +290,7 @@ def _run_agent_claude(cfg: dict, workspace: Path, session_dir: Path,
         model=(cfg.get("claude_model") or cfg.get("model")
                or claude_cli.DEFAULT_MODEL),
         cwd=workspace,
-        allowed_tools=claude_cli.AGENT_TOOLS,
+        tools=claude_cli.AGENT_TOOLS,
         meta_path=session_dir / f"claude-{task['name']}.json",
     )
     out = workspace / task["out"]

--- a/src/verify.py
+++ b/src/verify.py
@@ -1,4 +1,4 @@
-"""Phase 3: set up the worktree + run the deep-dive agents (DeepSeekHarness SDK).
+"""Phase 3: set up the worktree + run the deep-dive agents.
 
 One agent used to carry the whole review: claims, docs reality-check,
 requirement impact and review threads, in one prompt sharing one attention
@@ -10,6 +10,11 @@ parts are merged back into the one findings.json the rest of the pipeline
 already expects. Agents share the workspace read-only and write to separate
 part files, so nothing races; the global cap lives in src/agent_pool.py because
 autoreview may be running several of these reviews at once.
+
+Which agent runtime executes a task is a config choice, not a structural one:
+run_verify() picks a runner by provider (see RUNNERS), and every runner obeys
+the same contract — take one task, leave task["out"] in the workspace, return
+the reply text for the session log.
 """
 import json
 import subprocess
@@ -269,6 +274,57 @@ def _run_agent(cfg: dict, workspace: Path, session_dir: Path, task: dict) -> str
     return result.final_response
 
 
+def _run_agent_claude(cfg: dict, workspace: Path, session_dir: Path,
+                      task: dict) -> str:
+    """Same contract as _run_agent, backed by headless `claude -p`.
+
+    The CLI writes the part file itself through its Write tool. When it answers
+    with the JSON inline instead, salvaging it here costs a few lines and saves
+    the axis; without it read_part() reports "agent did not write it" and the
+    review ships a gap for what was really a formatting slip.
+    """
+    from src import claude_cli
+
+    response = claude_cli.run(
+        task["prompt"],
+        model=(cfg.get("claude_model") or cfg.get("model")
+               or claude_cli.DEFAULT_MODEL),
+        cwd=workspace,
+        allowed_tools=claude_cli.AGENT_TOOLS,
+        meta_path=session_dir / f"claude-{task['name']}.json",
+    )
+    out = workspace / task["out"]
+    if not out.exists():
+        salvaged = claude_cli.extract_json_object(response)
+        if salvaged is not None:
+            out.write_text(salvaged)
+    return response
+
+
+# Agent backends, by HARNESS_PROVIDER value.
+RUNNERS = {"deepseek": _run_agent, "claude": _run_agent_claude}
+DEFAULT_PROVIDER = "deepseek"
+
+
+def provider_of(cfg: dict) -> str:
+    return (cfg.get("provider") or DEFAULT_PROVIDER).strip().lower()
+
+
+def select_runner(cfg: dict):
+    """The agent backend named by cfg["provider"]."""
+    provider = provider_of(cfg)
+    if provider not in RUNNERS:
+        raise RuntimeError(
+            f"unknown provider {provider!r} — set HARNESS_PROVIDER to one of: "
+            f"{', '.join(sorted(RUNNERS))}")
+    return RUNNERS[provider]
+
+
+def backend_label(cfg: dict) -> str:
+    """provider/model, for the phase log the dashboard tails."""
+    return f"{provider_of(cfg)}/{cfg.get('model') or '?'}"
+
+
 def _execute(cfg: dict, workspace: Path, session_dir: Path, task: dict,
              runner) -> tuple[dict, dict | None, str | None]:
     """Run one agent under a global slot. Never raises — the caller decides.
@@ -304,7 +360,7 @@ def _execute(cfg: dict, workspace: Path, session_dir: Path, task: dict,
 def run_verify(cfg: dict, workspace: Path, session_dir: Path, snapshot: dict,
                claims: list[dict], runner=None) -> dict:
     """Fan out one agent per axis, merge the parts, validate and return findings."""
-    runner = runner or _run_agent
+    runner = runner or select_runner(cfg)
     session_dir.mkdir(parents=True, exist_ok=True)
     doc_candidates = rank_docs(workspace, snapshot, claims)
     tasks = plan_tasks(snapshot, claims, doc_candidates)
@@ -314,7 +370,8 @@ def run_verify(cfg: dict, workspace: Path, session_dir: Path, snapshot: dict,
     for task in tasks:
         (workspace / task["out"]).unlink(missing_ok=True)
 
-    print(f"      {len(tasks)} agents: {', '.join(t['name'] for t in tasks)}"
+    print(f"      {len(tasks)} agents on {backend_label(cfg)}: "
+          f"{', '.join(t['name'] for t in tasks)}"
           f" (cap {max_agents()} concurrent)", flush=True)
     with ThreadPoolExecutor(max_workers=len(tasks)) as pool:
         results = list(pool.map(

--- a/src/verify.py
+++ b/src/verify.py
@@ -285,6 +285,7 @@ def _run_agent_claude(cfg: dict, workspace: Path, session_dir: Path,
     """
     from src import claude_cli
 
+    out = workspace / task["out"]
     response = claude_cli.run(
         task["prompt"],
         model=(cfg.get("claude_model") or cfg.get("model")
@@ -292,8 +293,11 @@ def _run_agent_claude(cfg: dict, workspace: Path, session_dir: Path,
         cwd=workspace,
         tools=claude_cli.AGENT_TOOLS,
         meta_path=session_dir / f"claude-{task['name']}.json",
+        # An attempt that writes this and then dies in the API must not leave
+        # it behind for the retry: the salvage below would see a file already
+        # there and read the dead attempt's output as this agent's answer.
+        reset_paths=(out,),
     )
-    out = workspace / task["out"]
     if not out.exists():
         salvaged = claude_cli.extract_json_object(response)
         if salvaged is not None:

--- a/tests/test_autoreview.py
+++ b/tests/test_autoreview.py
@@ -513,3 +513,29 @@ def test_check_repos_exits_zero_when_all_reachable(tmp_path, monkeypatch):
         "src.gh.run_gh",
         lambda args, **kw: [] if args[1].startswith("orgs/") else "acme/good")
     assert main(["--check-repos", "--config", str(cfg)]) == 0
+
+
+def test_autoreview_stops_before_polling_when_claude_is_missing(tmp_path, monkeypatch, capsys):
+    """A review that dies in claim extraction leaves no findings, so decide_pr
+    queues the same PR again every interval — forever. Fail once instead."""
+    from src import claude_cli
+    from src.autoreview import main
+
+    cfg = tmp_path / "autoreview.yml"
+    cfg.write_text("org: sample-org\nrepos:\n  sample-app: auto\n")
+    monkeypatch.setenv("HARNESS_PROVIDER", "claude")
+    monkeypatch.setattr(claude_cli, "available", lambda: False)
+
+    assert main(["--once", "--config", str(cfg)]) == 2
+    assert "claude CLI is not on PATH" in capsys.readouterr().err
+
+
+def test_autoreview_rejects_an_unknown_provider(tmp_path, monkeypatch, capsys):
+    from src.autoreview import main
+
+    cfg = tmp_path / "autoreview.yml"
+    cfg.write_text("org: sample-org\nrepos:\n  sample-app: auto\n")
+    monkeypatch.setenv("HARNESS_PROVIDER", "cluade")
+
+    assert main(["--once", "--config", str(cfg)]) == 2
+    assert "unknown HARNESS_PROVIDER" in capsys.readouterr().err

--- a/tests/test_claims.py
+++ b/tests/test_claims.py
@@ -146,3 +146,34 @@ def test_all_inferred():
     assert not all_inferred([{"source": "inferred"}, {"source": "stated"}])
     assert not all_inferred([])
     assert not all_inferred(None)
+
+
+def test_select_chat_picks_the_backend_named_by_the_provider():
+    from src import claude_cli
+    from src.claims import select_chat
+    from src.llm import chat as openai_chat
+
+    assert select_chat(None) is openai_chat
+    assert select_chat("deepseek") is openai_chat
+    assert select_chat(" CLAUDE ") is claude_cli.chat
+
+
+def test_extract_claims_uses_the_provider_backend(tmp_path, monkeypatch):
+    """Phase 2 must not reach for DeepSeek when the review runs on Claude."""
+    from src import claude_cli
+    from src.claims import extract_claims
+
+    monkeypatch.setattr(
+        claude_cli, "run",
+        lambda prompt, **kw: '[{"id": "C1", "text": "adds a flag", '
+                             '"category": "feature"}]')
+    snapshot = {"title": "Add a --verbose flag",
+                "body": "This PR adds a --verbose flag to the CLI so that "
+                        "operators can see per-request timing in the log.",
+                "files": [{"filename": "cli.py"}], "commits": []}
+
+    claims = extract_claims(snapshot, {"provider": "claude", "model": "sonnet"},
+                            tmp_path)
+
+    assert [c["id"] for c in claims] == ["C1"]
+    assert claims[0]["source"] == "stated"

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -236,6 +236,35 @@ def test_run_does_not_retry_what_will_fail_again():
     assert len(calls) == 1
 
 
+def test_run_clears_the_previous_attempt_output_before_retrying(tmp_path):
+    """An attempt can write its file and then die in the API.
+
+    If the retry answers inline instead of writing, the caller's salvage sees
+    a file already sitting there, skips, and read_part() consumes the dead
+    attempt's half-written JSON as this agent's findings.
+    """
+    part = tmp_path / "findings-docs.json"
+    part.write_text('{"docs": [{"path": "stale"}]}')
+    seen = []
+    fake, _ = _sequence(API_ERROR, _envelope(result="answered inline"))
+
+    def watch(argv, **kwargs):
+        seen.append(part.exists())
+        return fake(argv, **kwargs)
+
+    claude_cli.run("hi", reset_paths=(part,), _run=watch,
+                   _sleep=lambda _: None)
+
+    # False on both attempts: the pre-existing file and the first attempt's.
+    assert seen == [False, False]
+
+
+def test_run_reset_paths_tolerates_a_missing_file(tmp_path):
+    fake, _ = _sequence(_envelope(result="fine"))
+    assert claude_cli.run("hi", reset_paths=(tmp_path / "never-written.json",),
+                          _run=fake) == "fine"
+
+
 def test_run_reports_why_the_run_ended_not_its_subtype():
     """subtype stays "success" for a run that died in the API."""
     fake, _ = _sequence(API_ERROR)

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -34,8 +34,7 @@ def _spy(stdout="", stderr="", returncode=0):
 
 def test_build_argv_hardens_against_the_reviewed_repo():
     """The workspace is an untrusted PR: it must not configure its own reviewer."""
-    argv = claude_cli.build_argv(model="sonnet",
-                                 allowed_tools=claude_cli.AGENT_TOOLS)
+    argv = claude_cli.build_argv(model="sonnet", tools=claude_cli.AGENT_TOOLS)
     assert argv[:2] == ["claude", "-p"]
     assert "--safe-mode" in argv          # no CLAUDE.md / hooks / skills from the repo
     assert "--strict-mcp-config" in argv  # no .mcp.json from the repo
@@ -46,11 +45,35 @@ def test_build_argv_hardens_against_the_reviewed_repo():
 
 def test_build_argv_passes_tools_as_one_comma_separated_argument():
     """Variadic space-separated tools would swallow the flag that follows them."""
-    argv = claude_cli.build_argv(model="sonnet",
-                                 allowed_tools=("Read", "Write"),
+    argv = claude_cli.build_argv(model="sonnet", tools=("Read", "Write"),
                                  system="be brief")
+    assert argv[argv.index("--tools") + 1] == "Read,Write"
     assert argv[argv.index("--allowedTools") + 1] == "Read,Write"
     assert argv[argv.index("--append-system-prompt") + 1] == "be brief"
+
+
+def test_tools_is_the_boundary_not_allowedtools():
+    """--allowedTools only pre-approves; a tool left out of it still exists.
+
+    Restricting reach with --allowedTools alone leaves Bash present and merely
+    unapproved, and a user settings rule can approve it — so the tool set has
+    to be cut with --tools, which decides what exists at all.
+    """
+    argv = claude_cli.build_argv(model="sonnet", tools=claude_cli.AGENT_TOOLS)
+    assert argv[argv.index("--tools") + 1] == "Read,Grep,Glob,Write"
+    assert "Bash" not in argv[argv.index("--tools") + 1]
+
+
+def test_no_tools_is_the_default_and_removes_every_tool():
+    """A new call site has to ask for reach rather than inherit it.
+
+    "" is the CLI's own spelling for "no tools at all" — verified against the
+    binary: with it, an instruction to run Bash produces no tool call and no
+    file on disk.
+    """
+    argv = claude_cli.build_argv(model="sonnet")
+    assert argv[argv.index("--tools") + 1] == ""
+    assert "--allowedTools" not in argv
 
 
 def test_agent_tools_grant_no_execution():
@@ -206,6 +229,8 @@ def test_chat_matches_the_llm_chat_signature_and_splits_the_roles(monkeypatch):
     prompt, kwargs = calls[0]
     assert out == "[]"
     assert prompt == "the PR description"
+    # Phase 2 has no sandboxed workspace and an untrusted prompt: no tools.
+    assert kwargs.get("tools", claude_cli.NO_TOOLS) == claude_cli.NO_TOOLS
     assert "you are a claim extractor" in kwargs["system"]
     # Phase 2 has no workspace, so a tool call is a wasted turn.
     assert claude_cli.NO_TOOLS_HINT in kwargs["system"]

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -186,6 +186,64 @@ def test_run_meta_failure_never_sinks_the_run(tmp_path):
                           _run=fake) == "fine"
 
 
+# --- retry on a failure that happened inside the API ------------------------
+
+def _sequence(*stdouts):
+    """Fake subprocess.run returning a different stdout per call."""
+    calls = []
+
+    def fake(argv, **kwargs):
+        calls.append(kwargs)
+        return _Proc(stdouts[min(len(calls) - 1, len(stdouts) - 1)])
+
+    return fake, calls
+
+
+API_ERROR = _envelope(is_error=True, terminal_reason="api_error",
+                      result="Not logged in · Please run /login")
+
+
+def test_run_retries_a_failure_inside_the_api():
+    """Four agents once died together on a blip while the CLI was logged in.
+
+    terminal_reason api_error, one turn, zero cost — and because nothing tried
+    twice, one transient moment cost the whole review.
+    """
+    fake, calls = _sequence(API_ERROR, _envelope(result="recovered"))
+    slept = []
+
+    assert claude_cli.run("hi", _run=fake, _sleep=slept.append) == "recovered"
+    assert len(calls) == 2
+    assert slept == [2]
+
+
+def test_run_gives_up_after_the_last_attempt():
+    fake, calls = _sequence(API_ERROR)
+
+    with pytest.raises(RuntimeError, match="after 3 attempts"):
+        claude_cli.run("hi", _run=fake, _sleep=lambda _: None)
+    assert len(calls) == 3
+
+
+def test_run_does_not_retry_what_will_fail_again():
+    """A bad model id costs the review time and reaches the same answer."""
+    fake, calls = _sequence(_envelope(is_error=True,
+                                      subtype="error_during_execution",
+                                      result="unknown model"))
+
+    with pytest.raises(RuntimeError, match="unknown model"):
+        claude_cli.run("hi", _run=fake, _sleep=lambda _: None)
+    assert len(calls) == 1
+
+
+def test_run_reports_why_the_run_ended_not_its_subtype():
+    """subtype stays "success" for a run that died in the API."""
+    fake, _ = _sequence(API_ERROR)
+
+    with pytest.raises(RuntimeError, match=r"failed \(api_error\)"):
+        claude_cli.run("hi", retries=1, _run=fake, _sleep=lambda _: None)
+
+
 # --- salvaging a part file the agent answered inline ------------------------
 
 def test_extract_json_object_reads_a_fenced_reply():

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -111,13 +111,22 @@ def test_run_raises_on_non_json_output():
         claude_cli.run("hi", _run=fake)
 
 
-def test_run_names_the_install_step_when_the_binary_is_missing():
-    """The error a user without Claude Code sees has to say what to do next."""
+def test_run_names_the_install_step_when_the_binary_is_missing(monkeypatch):
+    """The error has to say what to do next — and where it already looked.
+
+    The usual cause is not a missing install but a launcher (launchd, cron)
+    handing the process a PATH without the per-user bin dir: the same review
+    then works by hand and fails on a schedule, which is unreadable unless the
+    PATH is in the message.
+    """
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
     def fake(argv, **kwargs):
         raise FileNotFoundError(2, "No such file or directory", "claude")
 
-    with pytest.raises(RuntimeError, match="not found on PATH"):
+    with pytest.raises(RuntimeError, match="not found on PATH") as e:
         claude_cli.run("hi", _run=fake)
+    assert "PATH was: /usr/bin:/bin" in str(e.value)
 
 
 def test_run_turns_a_timeout_into_a_named_failure():

--- a/tests/test_claude_cli.py
+++ b/tests/test_claude_cli.py
@@ -1,0 +1,203 @@
+import json
+import subprocess
+
+import pytest
+
+from src import claude_cli
+
+
+class _Proc:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout, self.stderr, self.returncode = stdout, stderr, returncode
+
+
+def _envelope(**over) -> str:
+    data = {"type": "result", "subtype": "success", "is_error": False,
+            "result": "done", "total_cost_usd": 0.01, "session_id": "abc",
+            "permission_denials": []}
+    data.update(over)
+    return json.dumps(data)
+
+
+def _spy(stdout="", stderr="", returncode=0):
+    """Fake subprocess.run that records the call it was given."""
+    calls = []
+
+    def fake(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        return _Proc(stdout, stderr, returncode)
+
+    return fake, calls
+
+
+# --- command line -----------------------------------------------------------
+
+def test_build_argv_hardens_against_the_reviewed_repo():
+    """The workspace is an untrusted PR: it must not configure its own reviewer."""
+    argv = claude_cli.build_argv(model="sonnet",
+                                 allowed_tools=claude_cli.AGENT_TOOLS)
+    assert argv[:2] == ["claude", "-p"]
+    assert "--safe-mode" in argv          # no CLAUDE.md / hooks / skills from the repo
+    assert "--strict-mcp-config" in argv  # no .mcp.json from the repo
+    assert argv[argv.index("--setting-sources") + 1] == "user"
+    assert argv[argv.index("--output-format") + 1] == "json"
+    assert argv[argv.index("--model") + 1] == "sonnet"
+
+
+def test_build_argv_passes_tools_as_one_comma_separated_argument():
+    """Variadic space-separated tools would swallow the flag that follows them."""
+    argv = claude_cli.build_argv(model="sonnet",
+                                 allowed_tools=("Read", "Write"),
+                                 system="be brief")
+    assert argv[argv.index("--allowedTools") + 1] == "Read,Write"
+    assert argv[argv.index("--append-system-prompt") + 1] == "be brief"
+
+
+def test_agent_tools_grant_no_execution():
+    """Read the code, write one part file — a PR cannot make the agent run it."""
+    assert set(claude_cli.AGENT_TOOLS) == {"Read", "Grep", "Glob", "Write"}
+
+
+def test_build_argv_omits_optional_flags_when_unset():
+    argv = claude_cli.build_argv(model="sonnet", max_budget_usd=None)
+    assert "--allowedTools" not in argv
+    assert "--append-system-prompt" not in argv
+    assert "--max-budget-usd" not in argv
+
+
+# --- run --------------------------------------------------------------------
+
+def test_run_sends_the_prompt_over_stdin_not_argv(tmp_path):
+    """A claims prompt carries the whole diff digest — argv would hit ARG_MAX."""
+    fake, calls = _spy(_envelope(result="PONG"))
+    prompt = "x" * 5000
+
+    assert claude_cli.run(prompt, model="sonnet", cwd=tmp_path,
+                          _run=fake) == "PONG"
+    assert calls[0]["input"] == prompt
+    assert prompt not in calls[0]["argv"]
+    assert calls[0]["cwd"] == str(tmp_path)
+
+
+def test_run_raises_when_the_cli_reports_an_error():
+    fake, _ = _spy(_envelope(is_error=True, subtype="error_during_execution",
+                             result="model overloaded"))
+    with pytest.raises(RuntimeError, match="model overloaded"):
+        claude_cli.run("hi", _run=fake)
+
+
+def test_run_raises_on_a_non_success_subtype():
+    """max_turns / budget stops are is_error=False but produced no answer."""
+    fake, _ = _spy(_envelope(subtype="error_max_turns", result=""))
+    with pytest.raises(RuntimeError, match="error_max_turns"):
+        claude_cli.run("hi", _run=fake)
+
+
+def test_run_raises_on_empty_result():
+    fake, _ = _spy(_envelope(result="   "))
+    with pytest.raises(RuntimeError, match="empty result"):
+        claude_cli.run("hi", _run=fake)
+
+
+def test_run_reports_stderr_when_the_cli_prints_nothing():
+    fake, _ = _spy("", "not logged in", returncode=1)
+    with pytest.raises(RuntimeError, match="not logged in"):
+        claude_cli.run("hi", _run=fake)
+
+
+def test_run_raises_on_non_json_output():
+    fake, _ = _spy("Usage: claude [options]")
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        claude_cli.run("hi", _run=fake)
+
+
+def test_run_names_the_install_step_when_the_binary_is_missing():
+    """The error a user without Claude Code sees has to say what to do next."""
+    def fake(argv, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "claude")
+
+    with pytest.raises(RuntimeError, match="not found on PATH"):
+        claude_cli.run("hi", _run=fake)
+
+
+def test_run_turns_a_timeout_into_a_named_failure():
+    def fake(argv, **kwargs):
+        raise subprocess.TimeoutExpired(argv, 1800)
+
+    with pytest.raises(RuntimeError, match="timed out after 5s"):
+        claude_cli.run("hi", timeout=5, _run=fake)
+
+
+def test_run_writes_the_meta_sidecar_even_when_the_agent_failed(tmp_path):
+    """Cost and session id are the trail a failed agent leaves behind."""
+    meta = tmp_path / "sess" / "claude-docs.json"
+    fake, _ = _spy(_envelope(is_error=True, subtype="error_during_execution",
+                             result="boom", total_cost_usd=0.42))
+
+    with pytest.raises(RuntimeError):
+        claude_cli.run("hi", meta_path=meta, _run=fake)
+
+    saved = json.loads(meta.read_text())
+    assert saved["total_cost_usd"] == 0.42
+    assert saved["session_id"] == "abc"
+    # The reply itself already goes to agent-log-<axis>.txt; not stored twice.
+    assert "result" not in saved
+
+
+def test_run_meta_failure_never_sinks_the_run(tmp_path):
+    """A sidecar that cannot be written must not cost us the agent's answer."""
+    blocker = tmp_path / "blocked"
+    blocker.write_text("i am a file, not a directory")
+    fake, _ = _spy(_envelope(result="fine"))
+
+    assert claude_cli.run("hi", meta_path=blocker / "meta.json",
+                          _run=fake) == "fine"
+
+
+# --- salvaging a part file the agent answered inline ------------------------
+
+def test_extract_json_object_reads_a_fenced_reply():
+    text = 'Here you go:\n```json\n{"docs": [], "unresolved_questions": []}\n```'
+    assert json.loads(claude_cli.extract_json_object(text)) == {
+        "docs": [], "unresolved_questions": []}
+
+
+def test_extract_json_object_stops_at_the_matching_brace():
+    text = 'Result: {"a": {"b": 1}} — and some trailing prose {broken'
+    assert claude_cli.extract_json_object(text) == '{"a": {"b": 1}}'
+
+
+def test_extract_json_object_ignores_braces_inside_strings():
+    text = '{"note": "a } inside a string", "ok": true}'
+    assert json.loads(claude_cli.extract_json_object(text))["ok"] is True
+
+
+def test_extract_json_object_returns_none_when_there_is_nothing_to_salvage():
+    assert claude_cli.extract_json_object("no json here") is None
+    assert claude_cli.extract_json_object("") is None
+    assert claude_cli.extract_json_object('{"unterminated": ') is None
+
+
+# --- the chat adapter used by phase 2 ---------------------------------------
+
+def test_chat_matches_the_llm_chat_signature_and_splits_the_roles(monkeypatch):
+    """Same signature as src.llm.chat, so extract_claims takes either backend."""
+    calls = []
+    monkeypatch.setattr(claude_cli, "run",
+                        lambda prompt, **kw: calls.append((prompt, kw)) or "[]")
+
+    # api_key / base_url / max_tokens / retries exist only for signature
+    # compatibility — the CLI brings its own credentials, cap and retries.
+    out = claude_cli.chat(
+        [{"role": "system", "content": "you are a claim extractor"},
+         {"role": "user", "content": "the PR description"}],
+        model="sonnet", api_key="ignored", base_url="http://ignored",
+        max_tokens=49_152, retries=3)
+
+    prompt, kwargs = calls[0]
+    assert out == "[]"
+    assert prompt == "the PR description"
+    assert "you are a claim extractor" in kwargs["system"]
+    # Phase 2 has no workspace, so a tool call is a wasted turn.
+    assert claude_cli.NO_TOOLS_HINT in kwargs["system"]
+    assert kwargs["model"] == "sonnet"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,3 +26,36 @@ def test_load_config_from_env(monkeypatch):
     assert cfg.model == "deepseek-r1"
     assert cfg.base_url == "http://localhost:8000/v1"
     assert str(cfg.session_root) == "/tmp/my-sessions"
+
+
+def test_load_config_defaults_to_the_deepseek_backend(monkeypatch):
+    monkeypatch.delenv("HARNESS_PROVIDER", raising=False)
+    monkeypatch.delenv("HARNESS_CLAUDE_MODEL", raising=False)
+    cfg = load_config()
+    assert cfg.provider == "deepseek"
+    assert cfg.claude_model == "sonnet"
+    assert cfg.needs_deepseek_key is True
+
+
+def test_load_config_reads_the_claude_backend(monkeypatch):
+    monkeypatch.setenv("HARNESS_PROVIDER", " Claude ")
+    monkeypatch.setenv("HARNESS_CLAUDE_MODEL", "opus")
+    cfg = load_config()
+    assert cfg.provider == "claude"
+    assert cfg.claude_model == "opus"
+    # The CLI carries its own credentials, so a missing DeepSeek key is not a
+    # reason to refuse to start.
+    assert cfg.needs_deepseek_key is False
+
+
+def test_phase_cfg_resolves_the_model_for_the_active_provider(monkeypatch):
+    monkeypatch.setenv("DSH_MODEL", "deepseek-v4-flash")
+    monkeypatch.setenv("HARNESS_CLAUDE_MODEL", "opus")
+
+    monkeypatch.setenv("HARNESS_PROVIDER", "deepseek")
+    assert load_config().phase_cfg()["model"] == "deepseek-v4-flash"
+
+    monkeypatch.setenv("HARNESS_PROVIDER", "claude")
+    claude = load_config().phase_cfg()
+    assert claude["model"] == "opus"
+    assert claude["provider"] == "claude"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -221,6 +221,7 @@ def test_fixtures_mode_skips_review_lock(tmp_path, monkeypatch):
 
 
 def test_doctor_ready(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HARNESS_PROVIDER", "deepseek")
     monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
     monkeypatch.setattr("src.run.gh_available", lambda: True)
     monkeypatch.setattr("src.run.run_gh", lambda args, **kw: {"login": "dev1"})
@@ -235,6 +236,7 @@ def test_doctor_ready(tmp_path, monkeypatch, capsys):
 
 
 def test_doctor_missing_key(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HARNESS_PROVIDER", "deepseek")
     monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     monkeypatch.setattr("src.run.gh_available", lambda: True)
     monkeypatch.setattr("src.run.run_gh", lambda args, **kw: {"login": "dev1"})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -783,4 +783,5 @@ def test_header_backend_follows_a_restart(tmp_path, monkeypatch):
     assert "deepseek · <strong>deepseek-v4-flash</strong>" in client.get("/").text
 
     monkeypatch.setenv("HARNESS_PROVIDER", "claude")
+    monkeypatch.setenv("HARNESS_CLAUDE_MODEL", "sonnet")
     assert "claude · <strong>sonnet</strong>" in client.get("/").text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -257,6 +257,9 @@ def test_trigger_review_no_post_config(tmp_path, monkeypatch):
 
 
 def test_trigger_review_missing_key(tmp_path, monkeypatch):
+    # The key is only the DeepSeek backend's requirement, so the backend has to
+    # be named: otherwise the developer's own .env decides what this asserts.
+    monkeypatch.setenv("HARNESS_PROVIDER", "deepseek")
     monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     cfg_path = tmp_path / "autoreview.yml"
     cfg_path.write_text("org: sample-org\nrepos:\n  sample-app: auto\n")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -757,3 +757,30 @@ def test_stylesheet_is_cache_busted(tmp_path, monkeypatch):
     client, _ = _cfg_client(tmp_path, monkeypatch, lambda args, **kw: [])
     html = client.get("/").text
     assert f'href="/static/style.css?v={src.__version__}"' in html
+
+
+def test_header_names_the_agent_backend(tmp_path, monkeypatch):
+    """A review that quietly ran on the wrong provider must be visible up front.
+
+    The dashboard hands its own environment to every review it starts, so the
+    header is reporting the thing that actually does the work — not a second
+    setting that could disagree with it.
+    """
+    monkeypatch.setenv("HARNESS_PROVIDER", "claude")
+    monkeypatch.setenv("HARNESS_CLAUDE_MODEL", "opus")
+    client, _ = _cfg_client(tmp_path, monkeypatch, lambda args, **kw: [])
+
+    html = client.get("/").text
+    assert "claude · <strong>opus</strong>" in html
+    assert "HARNESS_PROVIDER=claude, HARNESS_CLAUDE_MODEL=opus" in html
+
+
+def test_header_backend_follows_a_restart(tmp_path, monkeypatch):
+    """Read per render, not cached at import — the value only matters when it changes."""
+    monkeypatch.setenv("HARNESS_PROVIDER", "deepseek")
+    monkeypatch.setenv("DSH_MODEL", "deepseek-v4-flash")
+    client, _ = _cfg_client(tmp_path, monkeypatch, lambda args, **kw: [])
+    assert "deepseek · <strong>deepseek-v4-flash</strong>" in client.get("/").text
+
+    monkeypatch.setenv("HARNESS_PROVIDER", "claude")
+    assert "claude · <strong>sonnet</strong>" in client.get("/").text

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -328,7 +328,9 @@ def test_verify_reports_progress_per_agent(tmp_path, capsys, monkeypatch):
     run_verify({"model": "m"}, ws, sd, SNAP, _claims(20), runner=runner)
 
     out = capsys.readouterr().out
-    assert "4 agents: claims-1, claims-2, docs, impact" in out
+    # The backend is named too: a review that silently ran on the wrong
+    # provider is otherwise indistinguishable in the live log.
+    assert "4 agents on deepseek/m: claims-1, claims-2, docs, impact" in out
     assert "cap 4 concurrent" in out
     for name in ("claims-1", "claims-2", "docs", "impact"):
         assert f"{name}: done in" in out
@@ -340,3 +342,65 @@ def test_verify_reports_a_failed_agent_in_the_log(tmp_path, capsys):
     run_verify({"model": "m"}, ws, sd, SNAP, _claims(1),
                runner=_fake_runner(PAYLOADS, fail=("docs",)))
     assert "docs: FAILED after" in capsys.readouterr().out
+
+
+# --- agent backend selection ------------------------------------------------
+
+def test_select_runner_defaults_to_the_sdk_backend():
+    from src.verify import RUNNERS, select_runner
+
+    assert select_runner({}) is RUNNERS["deepseek"]
+    assert select_runner({"provider": "  Claude "}) is RUNNERS["claude"]
+
+
+def test_select_runner_names_the_valid_providers():
+    """A typo in HARNESS_PROVIDER must not silently fall back to the default."""
+    from src.verify import select_runner
+
+    with pytest.raises(RuntimeError, match="claude, deepseek"):
+        select_runner({"provider": "cluade"})
+
+
+def test_backend_label_reports_what_actually_ran():
+    from src.verify import backend_label
+
+    assert backend_label({"model": "deepseek-v4-flash"}) == "deepseek/deepseek-v4-flash"
+    assert backend_label({"provider": "claude", "model": "opus"}) == "claude/opus"
+
+
+def test_claude_runner_salvages_a_part_answered_inline(tmp_path, monkeypatch):
+    """Losing a whole review axis to a formatting slip is not an acceptable trade."""
+    from src import claude_cli
+    from src.verify import _run_agent_claude
+
+    monkeypatch.setattr(
+        claude_cli, "run",
+        lambda prompt, **kw: 'Here it is:\n```json\n{"docs": [], '
+                             '"unresolved_questions": []}\n```')
+    ws, sd = tmp_path / "ws", tmp_path / "sd"
+    ws.mkdir()
+    task = {"name": "docs", "out": "findings-docs.json", "prompt": "..."}
+
+    _run_agent_claude({"claude_model": "sonnet"}, ws, sd, task)
+
+    assert json.loads((ws / "findings-docs.json").read_text()) == {
+        "docs": [], "unresolved_questions": []}
+
+
+def test_claude_runner_keeps_the_file_the_agent_wrote(tmp_path, monkeypatch):
+    """The Write tool is the normal path; salvage must never clobber it."""
+    from src import claude_cli
+    from src.verify import _run_agent_claude
+
+    ws, sd = tmp_path / "ws", tmp_path / "sd"
+    ws.mkdir()
+    written = {"docs": [{"path": "README.md", "status": "STALE", "what": "x"}],
+               "unresolved_questions": []}
+    (ws / "findings-docs.json").write_text(json.dumps(written))
+    monkeypatch.setattr(claude_cli, "run",
+                        lambda prompt, **kw: '{"docs": [], "unresolved_questions": []}')
+
+    _run_agent_claude({}, ws, sd, {"name": "docs", "out": "findings-docs.json",
+                                   "prompt": "..."})
+
+    assert json.loads((ws / "findings-docs.json").read_text()) == written

--- a/web/server.py
+++ b/web/server.py
@@ -43,8 +43,28 @@ def project_repo() -> dict | None:
     return None
 
 
+def agent_backend() -> dict:
+    """Provider + model that a review started from this dashboard will run on.
+
+    Registered as a callable and read per render, not cached at import: the
+    value is only interesting when it changes, and a cached one would keep
+    claiming DeepSeek after the server was restarted with
+    HARNESS_PROVIDER=claude — exactly the moment the header has a job to do.
+
+    run_review() hands the child process a copy of this process's environment,
+    so what the header shows is what the next review actually uses. It is not a
+    second setting that can drift from the one doing the work.
+    """
+    cfg = load_config()
+    model = cfg.phase_cfg()["model"]
+    model_env = "HARNESS_CLAUDE_MODEL" if cfg.provider == "claude" else "DSH_MODEL"
+    return {"provider": cfg.provider, "model": model,
+            "env": f"HARNESS_PROVIDER={cfg.provider}, {model_env}={model}"}
+
+
 # Set once so base.html can use it without every route threading it through.
 templates.env.globals["project_repo"] = project_repo()
+templates.env.globals["agent_backend"] = agent_backend
 # Stylesheet cache-buster: a CSS change otherwise needs a hard refresh, and
 # the header depends on CSS for layout it must not be broken without.
 try:

--- a/web/server.py
+++ b/web/server.py
@@ -11,7 +11,7 @@ from fastapi.templating import Jinja2Templates
 from src.autoreview_config import load_config as load_autoreview_config
 from src.autoreview_config import auto_repos, list_repos, remove_repo, set_repo_mode
 from src.autoreview_config import repo_mode as config_repo_mode
-from src.config import load_config
+from src.config import PROVIDERS, load_config
 from src.repo_check import ACTIONABLE, OK, UNKNOWN, check_repo, check_repos
 from src.review_proc import EXIT_TIMEOUT, run_review
 from web import metrics
@@ -467,7 +467,12 @@ def trigger_review(owner: str, repo: str, pr: int):
         raise HTTPException(status_code=400, detail=f"invalid config: {e}")
 
     env = load_config()
-    if not env.api_key:
+    if env.provider not in PROVIDERS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown HARNESS_PROVIDER={env.provider!r} — expected one "
+                   f"of: {', '.join(PROVIDERS)}")
+    if env.needs_deepseek_key and not env.api_key:
         raise HTTPException(status_code=400,
                             detail="DEEPSEEK_API_KEY not set (see .env.example)")
 

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -46,6 +46,17 @@ body {
 }
 .gh-mark { width: 16px; height: 16px; flex: none; }
 
+/* Which agent backend the next review runs on. Operational state, not
+   navigation: a review that quietly used the wrong provider is otherwise
+   invisible until the log has already scrolled past the line naming it.
+   Degrades to plain readable text ("claude · sonnet") with no CSS at all. */
+.backend {
+  font-size: 12px; color: #bdc3c7; white-space: nowrap;
+  border: 1px solid rgba(255, 255, 255, 0.25); border-radius: 999px;
+  padding: 2px 10px;
+}
+.backend strong { color: #fff; font-weight: 600; }
+
 .container { max-width: 1040px; margin: 24px auto; padding: 0 20px; }
 
 h1 { font-size: 22px; font-weight: 650; margin: 0 0 12px; letter-spacing: -0.2px; }

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -11,6 +11,9 @@
     <a class="brand" href="/">PR Review Dashboard</a>
     <a class="crumb" href="/config">Config</a>
     {% block nav %}{% endblock %}
+    {% set backend = agent_backend() %}
+    <span class="backend" title="Agent backend for new reviews — {{ backend.env }}"
+      >{{ backend.provider }} · <strong>{{ backend.model }}</strong></span>
     {% if project_repo %}
     <a class="crumb repo-link" target="_blank" rel="noopener"
        href="{{ project_repo.url }}" title="{{ project_repo.url }}">


### PR DESCRIPTION
## Why

A `HTTP 402 Insufficient Balance` from DeepSeek stops every review at phase 2,
and the pipeline had no other runtime to fall back to. Nothing in the review
logic actually depends on *which* agent reads the workspace — so the backend
becomes one env var instead of a fork threaded through the phases.

`HARNESS_PROVIDER` stays `deepseek` by default. Nothing changes for anyone who
does not set it.

```bash
export HARNESS_PROVIDER=claude
export HARNESS_CLAUDE_MODEL=claude-sonnet-5   # or an alias: sonnet / opus / haiku
harness-pr-review doctor                      # checks for the claude binary, not the SDK
```

No second API key: the Claude Code CLI carries its own credentials, so a
subscription login is enough.

## What

Both injection points already existed, so this fills them rather than
restructuring anything:

- `verify.py` took a `runner` — `RUNNERS` maps the provider to one, and
  `_run_agent_claude` fills the same contract via headless `claude -p`.
- `claims.py` took a `chat` — `claude_cli.chat` takes the same call
  `_run_pass` already makes. Its signature is compatible, not identical:
  `api_key` / `base_url` / `max_tokens` / `retries` are accepted and ignored,
  because the CLI carries its own. `_run_pass` itself changed in one respect —
  it now reads `api_key` / `base_url` with `.get()` instead of `[]`, so a
  provider config that has no use for them is not a `KeyError`.

`Config.phase_cfg()` puts the provider→model resolution in one place (both
phases call it), and `needs_deepseek_key` is the shared gate for the three
entry points that can start a review: the CLI, the autoreview poller, and the
dashboard's Review now. `doctor` reports per-provider readiness instead and so
branches on `provider` directly.

The header and the phase log both name the backend that actually ran, so a
review that quietly used the wrong one is visible rather than buried:

```
[4/5] verify — starting agents
      4 agents on claude/claude-sonnet-5: claims-1, claims-2, docs, impact (cap 8 concurrent)
```

## Sandboxing

The workspace is a PR from a repo we do not control.

- **`--tools Read,Grep,Glob,Write`** — no shell, no editing, no network. This
  is the flag that decides which built-in tools *exist*. `--allowedTools` is
  not a boundary — it only pre-approves what may run without a prompt, so a
  tool left off it is still present and a user settings rule can approve it.
  Both are passed, from the same list. (Caught in review; see the thread on
  `src/claude_cli.py`.)
- **Phase 2 runs with `--tools ""` — no tools at all.** It is text in, JSON
  out, its prompt carries the untrusted description and diff, and unlike phase
  3 it has no sandboxed workspace confining it.
- `--safe-mode`, `--setting-sources user`, `--strict-mcp-config`: a
  `CLAUDE.md`, hook, `.claude/settings.json` or `.mcp.json` **committed inside
  the reviewed repo is not loaded**.
- `--max-budget-usd` per agent. The existing global `HARNESS_MAX_AGENTS` cap
  applies unchanged — both backends run inside the same `agent_slot()`.

Per-agent cost, session id and any permission denial land in
`sessions/<owner>/<repo>/pr-<n>/claude-<axis>.json`.

## Verification

Run end-to-end three times on real PRs:

| PR | Files | Backend | Result | Cost |
|---|---|---|---|---|
| #24 | 3 | `claude/haiku` | 5/5 claims PASS, correct `file:line` evidence | $0.39 |
| nexpeakcore/erp#955 | 22 | `claude/sonnet` | 16 claims, 1 doc error, 15 impacts, posted to the PR | $4.08 |
| **this PR** | 17 | `claude/claude-sonnet-5` | 20 claims, and it found a real bug in itself | $2.66 |

The self-review is why the dashboard fix is in here: it flagged `README.md` as
`WRONG` because the Configuration table said `DEEPSEEK_API_KEY` was only
required by the deepseek backend, while `web/server.py`'s `trigger_review()`
still demanded it unconditionally and 400'd every review under the Claude
backend. The doc was right about the intent; the code had missed a call site.

Tests: **316 passed**. `tests/test_claude_cli.py` covers the tool boundary,
stdin prompt delivery, every error path (missing binary — with the PATH it
searched, timeout, `is_error`, non-success subtype, non-JSON output), the meta
sidecar, and the inline-JSON salvage that keeps a formatting slip from costing
a whole review axis.

Three tests that asserted default-provider behaviour while reading the
developer's own `.env` through `_load_dotenv()` now name the provider they
exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAwQFY42ctgNz4Gkhqesq7
